### PR TITLE
Add default extension (png) when saving image

### DIFF
--- a/NanoVNASaver/Chart.py
+++ b/NanoVNASaver/Chart.py
@@ -245,6 +245,8 @@ class Chart(QtWidgets.QWidget):
 
         logger.debug("Filename: %s", filename)
         if filename != "":
+            if not QtCore.QFileInfo(filename).suffix():
+                filename += ".png"
             self.grab().save(filename)
 
     def copy(self):

--- a/NanoVNASaver/NanoVNASaver.py
+++ b/NanoVNASaver/NanoVNASaver.py
@@ -1746,9 +1746,6 @@ class AboutWindow(QtWidgets.QWidget):
         top_layout = QtWidgets.QHBoxLayout()
         self.setLayout(top_layout)
         #self.setAutoFillBackground(True)
-        pal = self.palette()
-        pal.setColor(QtGui.QPalette.Background, QtGui.QColor("white"))
-        self.setPalette(pal)
         shortcut = QtWidgets.QShortcut(QtCore.Qt.Key_Escape, self, self.hide)
 
         icon_layout = QtWidgets.QVBoxLayout()


### PR DESCRIPTION
1. The chart image is saved only if explicitly specify the png extension. This patch solves this problem.

2. Remove white background from About window. It doesn't look pretty in a dark theme.
<img src="https://i.imgur.com/G90K2k5.png" />