### PR TITLE
Add auto pause checkbox feature to stop RF output after sweep

### DIFF
--- a/NanoVNASaver/Hardware.py
+++ b/NanoVNASaver/Hardware.py
@@ -192,6 +192,9 @@ class VNA:
     def setSweep(self, start, stop):
         self.writeSerial("sweep " + str(start) + " " + str(stop) + " 101")
 
+    def pauseSweep(self):
+        self.writeSerial("pause")
+
 
 class InvalidVNA(VNA):
     name = "Invalid"
@@ -200,6 +203,9 @@ class InvalidVNA(VNA):
         pass
 
     def setSweep(self, start, stop):
+        return
+        
+    def pauseSweep(self):
         return
 
     def resetSweep(self, start, stop):
@@ -352,6 +358,9 @@ class NanoVNA(VNA):
         else:
             self.writeSerial("sweep " + str(start) + " " + str(stop) + " 101")
             sleep(1)
+
+    def pauseSweep(self):
+        self.writeSerial("pause")
 
 
 class NanoVNA_H(NanoVNA):

--- a/NanoVNASaver/NanoVNASaver.py
+++ b/NanoVNASaver/NanoVNASaver.py
@@ -2050,7 +2050,7 @@ class SweepSettingsWindow(QtWidgets.QWidget):
         self.single_sweep_radiobutton = QtWidgets.QRadioButton("Single sweep")
         self.continuous_sweep_radiobutton = QtWidgets.QRadioButton("Continuous sweep")
         self.averaged_sweep_radiobutton = QtWidgets.QRadioButton("Averaged sweep")
-        self.auto_pause_sweep_checkbox = QtWidgets.QCheckBox("Pause hardware sweep after completion")
+        self.auto_pause_sweep_checkbox = QtWidgets.QCheckBox("Pause hardware stimulus after completion")
 
         settings_layout.addWidget(self.single_sweep_radiobutton)
         self.single_sweep_radiobutton.setChecked(True)

--- a/NanoVNASaver/NanoVNASaver.py
+++ b/NanoVNASaver/NanoVNASaver.py
@@ -2050,11 +2050,14 @@ class SweepSettingsWindow(QtWidgets.QWidget):
         self.single_sweep_radiobutton = QtWidgets.QRadioButton("Single sweep")
         self.continuous_sweep_radiobutton = QtWidgets.QRadioButton("Continuous sweep")
         self.averaged_sweep_radiobutton = QtWidgets.QRadioButton("Averaged sweep")
+        self.auto_pause_sweep_checkbox = QtWidgets.QCheckBox("Pause hardware sweep after completion")
 
         settings_layout.addWidget(self.single_sweep_radiobutton)
         self.single_sweep_radiobutton.setChecked(True)
         settings_layout.addWidget(self.continuous_sweep_radiobutton)
         settings_layout.addWidget(self.averaged_sweep_radiobutton)
+        settings_layout.addWidget(self.auto_pause_sweep_checkbox)
+        self.auto_pause_sweep_checkbox.setChecked(False)
 
         self.averages = QtWidgets.QLineEdit("3")
         self.truncates = QtWidgets.QLineEdit("0")
@@ -2066,6 +2069,7 @@ class SweepSettingsWindow(QtWidgets.QWidget):
 
         self.continuous_sweep_radiobutton.toggled.connect(
             lambda: self.app.worker.setContinuousSweep(self.continuous_sweep_radiobutton.isChecked()))
+        self.auto_pause_sweep_checkbox.toggled.connect(self.updateAutoPauseSweep)
         self.averaged_sweep_radiobutton.toggled.connect(self.updateAveraging)
         self.averages.textEdited.connect(self.updateAveraging)
         self.truncates.textEdited.connect(self.updateAveraging)
@@ -2162,6 +2166,9 @@ class SweepSettingsWindow(QtWidgets.QWidget):
         self.app.worker.setAveraging(self.averaged_sweep_radiobutton.isChecked(),
                                      self.averages.text(),
                                      self.truncates.text())
+                                     
+    def updateAutoPauseSweep(self):
+        self.app.worker.setAutoPauseSweep(self.auto_pause_sweep_checkbox.isChecked())
 
 
 class BandsWindow(QtWidgets.QWidget):

--- a/NanoVNASaver/SweepWorker.py
+++ b/NanoVNASaver/SweepWorker.py
@@ -53,6 +53,7 @@ class SweepWorker(QtCore.QRunnable):
         self.stopped = False
         self.running = False
         self.continuousSweep = False
+        self.autoPauseSweep = False
         self.averaging = False
         self.averages = 3
         self.truncates = 0
@@ -178,6 +179,9 @@ class SweepWorker(QtCore.QRunnable):
                      RFTools.parseFrequency(self.app.sweepEndInput.text()))
         self.vna.resetSweep(RFTools.parseFrequency(self.app.sweepStartInput.text()),
                             RFTools.parseFrequency(self.app.sweepEndInput.text()))
+
+        if self.autoPauseSweep:
+            self.vna.pauseSweep()
 
         self.percentage = 100
         logger.debug("Sending \"finished\" signal")
@@ -329,6 +333,8 @@ class SweepWorker(QtCore.QRunnable):
         # S21
         values21 = self.readData("data 1")
 
+        if self.autoPauseSweep:
+            self.vna.pauseSweep()
         return frequencies, values11, values21
 
     def readData(self, data):
@@ -371,6 +377,8 @@ class SweepWorker(QtCore.QRunnable):
                     raise NanoVNAValueException("Failed reading " + str(data) + " " + str(count) + " times.\n" +
                                                 "Data outside expected valid ranges, or in an unexpected format.\n\n" +
                                                 "You can disable data validation on the device settings screen.")
+        if self.autoPauseSweep:
+            self.vna.pauseSweep()
         return returndata
 
     def readFreq(self):
@@ -399,6 +407,9 @@ class SweepWorker(QtCore.QRunnable):
                         raise NanoVNAValueException("Failed reading frequencies " + str(count) + " times.")
                 else:
                     returnfreq.append(int(f))
+
+        if self.autoPauseSweep:
+            self.vna.pauseSweep()
         return returnfreq
 
     def setContinuousSweep(self, continuous_sweep: bool):
@@ -411,6 +422,9 @@ class SweepWorker(QtCore.QRunnable):
             self.truncates = int(truncates)
         except ValueError:
             return
+            
+    def setAutoPauseSweep(self, auto_pause_sweep: bool):
+        self.autoPauseSweep = auto_pause_sweep
 
     def setVNA(self, vna):
         self.vna = vna


### PR DESCRIPTION
Does not fix https://github.com/mihtjel/nanovna-saver/issues/128 as it does not stop the stimulus on the sweeping of the stimulus.

- I tagged on a new checkbox to the bottom of the 3 radio buttons for simplicity. 
- I tested with my NanoVNA-H and did not see any thing strange.
- I *think* I got all the right places to send the pause command after sweep/scan is started. Today is the first day of looking at the code so I may have missed something :)

New checkbox under sweep settings:
![image](https://user-images.githubusercontent.com/13027044/79992654-68a87080-8479-11ea-90cf-b2e6a6e8427b.png)
