### PR TITLE
repair crash with no device attached

### DIFF
--- a/NanoVNASaver/Analysis/AntennaAnalysis.py
+++ b/NanoVNASaver/Analysis/AntennaAnalysis.py
@@ -10,7 +10,7 @@ import math
 
 from NanoVNASaver.Analysis import Analysis
 
-from NanoVNASaver.Hardware import InvalidVNA
+from NanoVNASaver.Hardware import VNA
 
 import numpy as np
 from NanoVNASaver.Marker import Marker

--- a/NanoVNASaver/NanoVNASaver.py
+++ b/NanoVNASaver/NanoVNASaver.py
@@ -618,6 +618,9 @@ class NanoVNASaver(QtWidgets.QWidget):
             except serial.SerialException as exc:
                 logger.error("Tried to open %s and failed: %s", self.serialPort, exc)
                 return
+            if not self.serial.isOpen() :
+                logger.error("Unable to open port %s", self.serialPort)
+                return
             self.btnSerialToggle.setText("Disconnect")
 
         sleep(0.05)


### PR DESCRIPTION
This repairs the issue I just added (crash when click connect with no device) and it repairs a small typo in AntennaAnalysis that stops execution.