### PR TITLE
Fix #323

### DIFF
--- a/NanoVNASaver/Hardware/NanoVNA_V2.py
+++ b/NanoVNASaver/Hardware/NanoVNA_V2.py
@@ -143,14 +143,14 @@ class NanoVNA_V2(VNA):
 
                     # serial .read() will try to read nBytes bytes in timeout secs
                     arr = self.serial.read(nBytes)
-                    if nBytes != len(arr) :
+                    if nBytes != len(arr):
                         logger.warning("expected %d bytes, got %d",
-                                     nBytes, len(arr))
+                                       nBytes, len(arr))
                         # the way to retry on timeout is keep the data already read
                         # then try to read the rest of the data into the array
-                        if nBytes > len(arr) :
+                        if nBytes > len(arr):
                             arr = arr + self.serial.read(nBytes - len(arr))
-                    if nBytes != len(arr) :
+                    if nBytes != len(arr):
                         return []
 
                     freq_index = -1
@@ -227,7 +227,8 @@ class NanoVNA_V2(VNA):
     def _updateSweep(self):
         s21hack = "S21 hack" in self.features
         cmd = pack("<BBQ", _CMD_WRITE8, _ADDR_SWEEP_START,
-                   int(self.sweepStartHz - (self.sweepStepHz * s21hack)))
+                   max(50000,
+                       int(self.sweepStartHz - (self.sweepStepHz * s21hack))))
         cmd += pack("<BBQ", _CMD_WRITE8,
                     _ADDR_SWEEP_STEP, int(self.sweepStepHz))
         cmd += pack("<BBH", _CMD_WRITE2,

--- a/NanoVNASaver/SweepWorker.py
+++ b/NanoVNASaver/SweepWorker.py
@@ -263,7 +263,7 @@ class SweepWorker(QtCore.QRunnable):
         logger.debug("Read %s frequencies", len(frequencies))
         values11 = self.readData("data 0")
         values21 = self.readData("data 1")
-        if not (len(frequencies) == len(values11) == len(values21)):
+        if not len(frequencies) == len(values11) == len(values21):
             logger.info("No valid data during this run")
             return [], [], []
         return frequencies, values11, values21


### PR DESCRIPTION
As consequence of the S21 bugfix, V2 start frequency (first point)
could be calculated to a negative value if the span was greater than
the start frequency.
Now start frequency is forced to be at least 50kHz
