### PR TITLE
try to read initial frequencies

### DIFF
--- a/NanoVNASaver/Hardware/NanoVNA.py
+++ b/NanoVNASaver/Hardware/NanoVNA.py
@@ -40,9 +40,24 @@ class NanoVNA(VNA):
         super().__init__(iface)
         self.sweep_method = "sweep"
         self.read_features()
-        self.start = 27000000
-        self.stop = 30000000
+        logger.debug("Setting initial start,stop")
+        self.start, self.stop = self._get_running_frequencies()
         self._sweepdata = []
+
+    def _get_running_frequencies(self):
+
+        if self.name == "NanoVNA":
+            logger.debug("Reading values: frequencies")
+            try:
+                frequencies = super().readValues("frequencies")
+                return frequencies[0], frequencies[-1]
+            except Exception as e:
+                logger.warning("%s reading frequencies", e)
+                logger.info("falling back to generic")
+        else:
+            logger.debug("Name %s, fallback to generic", self.name)
+
+        return VNA._get_running_frequencies(self)
 
     def _capture_data(self) -> bytes:
         timeout = self.serial.timeout

--- a/NanoVNASaver/Hardware/VNA.py
+++ b/NanoVNASaver/Hardware/VNA.py
@@ -146,6 +146,14 @@ class VNA:
     def resetSweep(self, start: int, stop: int):
         pass
 
+    def _get_running_frequencies(self):
+        '''
+        If possible, read frequencies already runnung
+        if not return default values
+        Overwrite in specific HW
+        '''
+        return 27000000, 30000000
+
     def connected(self) -> bool:
         return self.serial.is_open
 


### PR DESCRIPTION
MUST try with version != original nanovna !!!

see https://github.com/NanoVNA-Saver/nanovna-saver/issues/347

Only for V1 read frequencies,
for other must overwrite  _get_running_frequencies()

