### PR TITLE
Add new s21 markers for |Z| and R+jX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 settings.json
 .gitignore
 .coverage
+/nanovna-saver.exe.spec

--- a/NanoVNASaver/Marker/Values.py
+++ b/NanoVNASaver/Marker/Values.py
@@ -54,6 +54,10 @@ TYPES = (
     Label("s21phase", "S21 Phase", "S21 Phase", True),
     Label("s21polar", "S21 Polar", "S21 Polar", False),
     Label("s21groupdelay", "S21 Group Delay", "S21 Group Delay", False),
+    Label("s21magshunt", "S21 |Z| shunt", "S21 Z Magnitude shunt", False),
+    Label("s21magseries", "S21 |Z| series", "S21 Z Magnitude series", False),
+    Label("s21realimagshunt", "S21 R+jX shunt", "S21 Z Real+Imag shunt", False),
+    Label("s21realimagseries", "S21 R+jX series", "S21 Z Real+Imag series", False),
 )
 
 

--- a/NanoVNASaver/Marker/Widget.py
+++ b/NanoVNASaver/Marker/Widget.py
@@ -351,3 +351,7 @@ class Marker(QtCore.QObject, Value):
             self.label['s21phase'].setText(format_phase(s21.phase))
             self.label['s21polar'].setText(
                 str(round(abs(s21.z), 2)) + "∠" + format_phase(s21.phase))
+            self.label['s21magshunt'].setText(format_magnitude(abs(s21.shuntImpedance())))
+            self.label['s21magseries'].setText(format_magnitude(abs(s21.seriesImpedance())))
+            self.label['s21realimagshunt'].setText(format_complex_imp(s21.shuntImpedance(), allow_negative=True))
+            self.label['s21realimagseries'].setText(format_complex_imp(s21.seriesImpedance(), allow_negative=True))


### PR DESCRIPTION
Adds new markers for
S21 |Z| shunt
S21 |Z| series
S21 R+jX shunt
S21 R+jX series

issue https://github.com/NanoVNA-Saver/nanovna-saver/issues/165