### PR TITLE
Add support for setting TX power on NanoVNA v2

### DIFF
--- a/NanoVNASaver/Hardware/AVNA.py
+++ b/NanoVNASaver/Hardware/AVNA.py
@@ -29,6 +29,7 @@ class AVNA(VNA):
 
     def __init__(self, iface: Interface):
         super().__init__(iface)
+        self.sweep_max_freq_Hz = 40e3
         self.features.add("Customizable data points")
 
     def isValid(self):

--- a/NanoVNASaver/Hardware/NanoVNA.py
+++ b/NanoVNASaver/Hardware/NanoVNA.py
@@ -42,6 +42,7 @@ class NanoVNA(VNA):
         self.read_features()
         logger.debug("Setting initial start,stop")
         self.start, self.stop = self._get_running_frequencies()
+        self.sweep_max_freq_Hz = 300e6
         self._sweepdata = []
 
     def _get_running_frequencies(self):

--- a/NanoVNASaver/Hardware/NanoVNA_F.py
+++ b/NanoVNASaver/Hardware/NanoVNA_F.py
@@ -23,6 +23,7 @@ import numpy as np
 from PyQt5 import QtGui
 
 from NanoVNASaver.Hardware.NanoVNA import NanoVNA
+from NanoVNASaver.Hardware.Serial import Interface
 
 logger = logging.getLogger(__name__)
 
@@ -31,3 +32,7 @@ class NanoVNA_F(NanoVNA):
     name = "NanoVNA-F"
     screenwidth = 800
     screenheight = 480
+
+    def __init__(self, iface: Interface):
+        super().__init__(iface)
+        self.sweep_max_freq_Hz = 1500e6

--- a/NanoVNASaver/Hardware/NanoVNA_F_V2.py
+++ b/NanoVNASaver/Hardware/NanoVNA_F_V2.py
@@ -6,6 +6,7 @@ import numpy as np
 from PyQt5 import QtGui
 
 from NanoVNASaver.Hardware.NanoVNA import NanoVNA
+from NanoVNASaver.Hardware.Serial import Interface
 
 logger = logging.getLogger(__name__)
 
@@ -14,6 +15,10 @@ class NanoVNA_F_V2(NanoVNA):
     name = "NanoVNA-F_V2"
     screenwidth = 800
     screenheight = 480
+
+    def __init__(self, iface: Interface):
+        super().__init__(iface)
+        self.sweep_max_freq_Hz = 3e9
 
     def getScreenshot(self) -> QtGui.QPixmap:
         logger.debug("Capturing screenshot...")

--- a/NanoVNASaver/Hardware/NanoVNA_H.py
+++ b/NanoVNASaver/Hardware/NanoVNA_H.py
@@ -19,9 +19,14 @@
 import logging
 
 from NanoVNASaver.Hardware.NanoVNA import NanoVNA
+from NanoVNASaver.Hardware.Serial import Interface
 
 logger = logging.getLogger(__name__)
 
 
 class NanoVNA_H(NanoVNA):
     name = "NanoVNA-H"
+
+    def __init__(self, iface: Interface):
+        super().__init__(iface)
+        self.sweep_max_freq_Hz = 1500e6

--- a/NanoVNASaver/Hardware/NanoVNA_H4.py
+++ b/NanoVNASaver/Hardware/NanoVNA_H4.py
@@ -31,6 +31,7 @@ class NanoVNA_H4(NanoVNA_H):
 
     def __init__(self, iface: Interface):
         super().__init__(iface)
+        self.sweep_max_freq_Hz = 1500e6
         self.sweep_method = "scan"
         if "Scan mask command" in self.features:
             self.sweep_method = "scan_mask"

--- a/NanoVNASaver/Hardware/NanoVNA_V2.py
+++ b/NanoVNASaver/Hardware/NanoVNA_V2.py
@@ -94,6 +94,11 @@ class NanoVNA_V2(VNA):
         self.features.add("Customizable data points")
         # TODO: more than one dp per freq
         self.features.add("Multi data points")
+        self.board_revision = self.read_board_revision()
+        if self.board_revision >= Version("2.0.4"):
+            self.sweep_max_freq_Hz = 4400e6
+        else:
+            self.sweep_max_freq_Hz = 3000e6
         if self.version <= Version("1.0.1"):
             logger.debug("Hack for s21 oddity in first sweeppoint")
             self.features.add("S21 hack")
@@ -210,7 +215,9 @@ class NanoVNA_V2(VNA):
         if len(resp) != 2:
             logger.error("Timeout reading version registers")
             return None
-        return Version(f"{resp[0]}.0.{resp[1]}")
+        result = Version(f"{resp[0]}.0.{resp[1]}")
+        logger.debug("read_board_revision: %s", result)
+        return result
 
 
     def setSweep(self, start, stop):

--- a/NanoVNASaver/Hardware/NanoVNA_V2.py
+++ b/NanoVNASaver/Hardware/NanoVNA_V2.py
@@ -57,6 +57,15 @@ _ADDR_FW_MINOR = 0xf4
 
 WRITE_SLEEP = 0.05
 
+_ADF4350_TXPOWER_DESC_MAP = {
+    0: '9dB attenuation',
+    1: '6dB attenuation',
+    2: '3dB attenuation',
+    3: 'Maximum',
+}
+_ADF4350_TXPOWER_DESC_REV_MAP = {
+    value: key for key, value in _ADF4350_TXPOWER_DESC_MAP.items()}
+
 class NanoVNA_V2(VNA):
     name = "NanoVNA-V2"
     valid_datapoints = (101, 11, 51, 201, 301, 501, 1023)
@@ -102,6 +111,13 @@ class NanoVNA_V2(VNA):
         if self.version <= Version("1.0.1"):
             logger.debug("Hack for s21 oddity in first sweeppoint")
             self.features.add("S21 hack")
+        if self.version >= Version("1.0.2"):
+            self.features.update({"Set TX power partial", "Set Average"})
+            # Can only set ADF4350 power, i.e. for >= 140MHz
+            self.txPowerRanges = [
+                ((140e6, self.sweep_max_freq_Hz),
+                 [_ADF4350_TXPOWER_DESC_MAP[value] for value in (3, 2, 1, 0)]),
+            ]
 
     def readFirmware(self) -> str:
         result = f"HW: {self.read_board_revision()}\nFW: {self.version}"
@@ -245,3 +261,21 @@ class NanoVNA_V2(VNA):
         with self.serial.lock:
             self.serial.write(cmd)
             sleep(WRITE_SLEEP)
+
+    def setTXPower(self, freq_range, power_desc):
+        if freq_range[0] != 140e6:
+            raise ValueError('Invalid TX power frequency range')
+        # 140MHz..max => ADF4350
+        self._set_register(0x42, _ADF4350_TXPOWER_DESC_REV_MAP[power_desc], 1)
+
+    def _set_register(self, addr, value, size):
+        if size == 1:
+            packet = pack("<BBB", _CMD_WRITE, addr, value)
+        elif size == 2:
+            packet = pack("<BBH", _CMD_WRITE2, addr, value)
+        elif size == 4:
+            packet = pack("<BBI", _CMD_WRITE4, addr, value)
+        elif size == 8:
+            packet = pack("<BBQ", _CMD_WRITE8, addr, value)
+        self.serial.write(packet)
+        logger.debug("set register %02x (size %d) to %x", addr, size, value)

--- a/NanoVNASaver/Hardware/VNA.py
+++ b/NanoVNASaver/Hardware/VNA.py
@@ -58,6 +58,9 @@ class VNA:
         self.bandwidth = 1000
         self.bw_method = "ttrftech"
         self.sweep_max_freq_Hz = None
+        # [((min_freq, max_freq), [description]]. Order by increasing
+        # frequency. Put default output power first.
+        self.txPowerRanges = []
         if self.connected():
             self.version = self.readVersion()
             self.read_features()
@@ -196,3 +199,6 @@ class VNA:
 
     def setSweep(self, start, stop):
         list(self.exec_command(f"sweep {start} {stop} {self.datapoints}"))
+
+    def setTXPower(self, freq_range, power_desc):
+        raise NotImplementedError()

--- a/NanoVNASaver/Hardware/VNA.py
+++ b/NanoVNASaver/Hardware/VNA.py
@@ -57,6 +57,7 @@ class VNA:
         self.datapoints = self.valid_datapoints[0]
         self.bandwidth = 1000
         self.bw_method = "ttrftech"
+        self.sweep_max_freq_Hz = None
         if self.connected():
             self.version = self.readVersion()
             self.read_features()

--- a/NanoVNASaver/NanoVNASaver.py
+++ b/NanoVNASaver/NanoVNASaver.py
@@ -571,6 +571,8 @@ class NanoVNASaver(QtWidgets.QWidget):
         self.sweep_control.update_center_span()
         self.sweep_control.update_step_size()
 
+        self.windows["sweep_settings"].vna_connected()
+
         logger.debug("Starting initial sweep")
         self.sweep_start()
 
@@ -840,3 +842,6 @@ class NanoVNASaver(QtWidgets.QWidget):
     def update_sweep_title(self):
         for c in self.subscribing_charts:
             c.setSweepTitle(self.sweep.properties.name)
+
+    def set_tx_power(self, freq_range, power_desc):
+        self.vna.setTXPower(freq_range, power_desc)


### PR DESCRIPTION
As of firmware version 1.0.2 (tag 20210214) the output power of the TX ADF4350 can be configured via USB (register 0x42).  Add support for this setting in NanoVNASaver.

In order to correctly show the frequencies that will be affected by the setting we need to know the maximum stop frequency of the VNA. Add this information for all supported VNA models.

**WARNING**: The automatic first sweep after connecting to the VNA will be performed at maximum power (default). Sensitive equipment should not be connected until after NanoVNASaver has connected to the NanoVNA v2 and the setting has been changed.

Screenshot of the modified sweep settings window while connected to a NanoVNA v2 with firmware 1.0.2:
![tx_power](https://user-images.githubusercontent.com/4546556/113691270-8a235c00-96cc-11eb-8580-296d8a2dd6ff.png)

The branching model isn't quite clear to me. The Development branch is lagging behind the testing branch so I've targeted the testing branch. Please let me know if I should base on some other branch instead.