### PR TITLE
Format shrinking and better -H detection

### DIFF
--- a/NanoVNASaver/Hardware/Hardware.py
+++ b/NanoVNASaver/Hardware/Hardware.py
@@ -140,6 +140,8 @@ def detect_version(serial_port: serial.Serial) -> str:
         # -H versions
         if data.startswith("\r\nch> "):
             return "vh"
+        if data.startswith("\r\n?\r\nch> "):
+            return "vh"
         if data.startswith("2"):
             return "v2"
         logger.debug("Retry detection: %s", i + 1)

--- a/NanoVNASaver/Marker/Widget.py
+++ b/NanoVNASaver/Marker/Widget.py
@@ -87,7 +87,7 @@ class Marker(QtCore.QObject, Value):
             self.name = f"Marker {Marker._instances}"
 
         self.frequencyInput = FrequencyInput()
-        self.frequencyInput.setFixedHeight(20)
+        self.frequencyInput.setMinimumHeight(20)
         self.frequencyInput.setAlignment(QtCore.Qt.AlignRight)
         self.frequencyInput.editingFinished.connect(
             lambda: self.setFrequency(
@@ -108,7 +108,7 @@ class Marker(QtCore.QObject, Value):
         ###############################################################
 
         self.btnColorPicker = QtWidgets.QPushButton("█")
-        self.btnColorPicker.setFixedHeight(20)
+        self.btnColorPicker.setMinimumHeight(20)
         self.btnColorPicker.setFixedWidth(20)
         self.btnColorPicker.clicked.connect(
             lambda: self.setColor(QtWidgets.QColorDialog.getColor(
@@ -143,7 +143,9 @@ class Marker(QtCore.QObject, Value):
 
         # line only if more then 3 selected
         self.left_form = QtWidgets.QFormLayout()
+        self.left_form.setVerticalSpacing(0)
         self.right_form = QtWidgets.QFormLayout()
+        self.right_form.setVerticalSpacing(0)
         box_layout.addLayout(self.left_form)
         box_layout.addWidget(line)
         box_layout.addLayout(self.right_form)

--- a/NanoVNASaver/NanoVNASaver.py
+++ b/NanoVNASaver/NanoVNASaver.py
@@ -255,7 +255,7 @@ class NanoVNASaver(QtWidgets.QWidget):
             self.marker_data_layout.addWidget(m.get_data_layout())
 
         scroll2 = QtWidgets.QScrollArea()
-        scroll2.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOn)
+        #scroll2.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOn)
         scroll2.setWidgetResizable(True)
         scroll2.setVisible(True)
 
@@ -277,6 +277,7 @@ class NanoVNASaver(QtWidgets.QWidget):
         s11_control_box = QtWidgets.QGroupBox()
         s11_control_box.setTitle("S11")
         s11_control_layout = QtWidgets.QFormLayout()
+        s11_control_layout.setVerticalSpacing(0)
         s11_control_box.setLayout(s11_control_layout)
 
         self.s11_min_swr_label = QtWidgets.QLabel()
@@ -289,6 +290,7 @@ class NanoVNASaver(QtWidgets.QWidget):
         s21_control_box = QtWidgets.QGroupBox()
         s21_control_box.setTitle("S21")
         s21_control_layout = QtWidgets.QFormLayout()
+        s21_control_layout.setVerticalSpacing(0)
         s21_control_box.setLayout(s21_control_layout)
 
         self.s21_min_gain_label = QtWidgets.QLabel()


### PR DESCRIPTION
my -H with DiSlord's NanoVNA-D FW (V.1.0.65) responds to `\r` with
````
?
ch> 
````
which lead to this logger error:
````
NanoVNASaver.Hardware.Hardware - ERROR - No VNA detected. Hardware responded to CR with: 
?
ch> 
````