### PR TITLE
Added three types of coax from The Wireman to NanoVNASaver/Windows/TD…

### DIFF
--- a/NanoVNASaver/Windows/TDR.py
+++ b/NanoVNASaver/Windows/TDR.py
@@ -63,6 +63,10 @@ class TDRWindow(QtWidgets.QWidget):
         self.tdr_velocity_dropdown.addItem("RG-8/U Foam (Belden 8214) (0.78)", 0.78)
         self.tdr_velocity_dropdown.addItem("RG-8/U (Belden 9913) (0.84)", 0.84)
         self.tdr_velocity_dropdown.addItem("RG-8X (Belden 9258) (0.82)", 0.82)
+        # Added by EKZ, KC3KZ, from measurement of actual cable
+        self.tdr_velocity_dropdown.addItem("RG-8X (Wireman \"Super 8\" CQ106) (0.81)", 0.81)
+        self.tdr_velocity_dropdown.addItem("RG-8X (Wireman \"MINI-8 Lo-Loss\" CQ118) (0.82)", 0.82)
+        self.tdr_velocity_dropdown.addItem("RG-58 (Wireman \"CQ 58 Lo-Loss Flex\" CQ129FF) (0.79)", 0.79)
         self.tdr_velocity_dropdown.addItem(
             "RG-11/U 75\N{OHM SIGN} Foam HDPE (Belden 9292) (0.84)", 0.84)
         self.tdr_velocity_dropdown.addItem("RG-58/U 52\N{OHM SIGN} PE (Belden 9201) (0.66)", 0.66)


### PR DESCRIPTION
…R.py.

These three coax cables were ones that I had available. I physically measured the length with a 100 ft tape measure and adjusted the velocity factor in the TDR window so that the electrically-measured length matched the physically-measured length. The electrical lengths were collected with a NanoVNA-H, HW 3.1 using firmware 1.0.64 and with proper calibration.

Let me know if you have any questions.

-Kevin Zembower
KC3KZ