### PR TITLE
Change calculation of admittance value and unit in marker plotting code

### DIFF
--- a/NanoVNASaver/Formatting.py
+++ b/NanoVNASaver/Formatting.py
@@ -110,6 +110,18 @@ def format_phase(val: float) -> str:
     return f"{math.degrees(val):.2f}""\N{DEGREE SIGN}"
 
 
+def format_complex_adm(z: complex, allow_negative: bool = False) -> str:
+    if z == 0:
+        return "- S"
+    adm = 1/z
+
+    fmt_re = FMT_COMPLEX
+    if allow_negative:
+        fmt_re = FMT_COMPLEX_NEG
+    re = SITools.Value(adm.real, fmt=fmt_re)
+    im = SITools.Value(abs(adm.imag), fmt=FMT_COMPLEX)
+    return f"{re}{'-' if adm.imag < 0 else '+'}j{im} S"
+
 def format_complex_imp(z: complex, allow_negative: bool = False) -> str:
     fmt_re = FMT_COMPLEX
     if allow_negative:

--- a/NanoVNASaver/Marker/Delta.py
+++ b/NanoVNASaver/Marker/Delta.py
@@ -21,6 +21,7 @@ from PyQt5 import QtCore
 from NanoVNASaver import RFTools
 from NanoVNASaver.Formatting import (
     format_capacitance,
+    format_complex_adm,
     format_complex_imp,
     format_frequency_space,
     format_gain,
@@ -90,7 +91,7 @@ class DeltaMarker(Marker):
             format_frequency_space(s11_b.freq - s11_a.freq))
         self.label['lambda'].setText(
             format_wavelength(s11_b.wavelength - s11_a.wavelength))
-        self.label['admittance'].setText(format_complex_imp(imp_p, True))
+        self.label['admittance'].setText(format_complex_adm(imp_p, True))
         self.label['impedance'].setText(format_complex_imp(imp, True))
 
         self.label['parc'].setText(cap_p_str)

--- a/NanoVNASaver/Marker/Widget.py
+++ b/NanoVNASaver/Marker/Widget.py
@@ -25,6 +25,7 @@ from PyQt5.QtCore import pyqtSignal
 from NanoVNASaver import RFTools
 from NanoVNASaver.Formatting import (
     format_capacitance,
+    format_complex_adm,
     format_complex_imp,
     format_frequency_space,
     format_gain,
@@ -328,7 +329,7 @@ class Marker(QtCore.QObject, Value):
 
         self.label['actualfreq'].setText(format_frequency_space(_s11.freq))
         self.label['lambda'].setText(format_wavelength(_s11.wavelength))
-        self.label['admittance'].setText(format_complex_imp(imp_p))
+        self.label['admittance'].setText(format_complex_adm(imp))
         self.label['impedance'].setText(format_complex_imp(imp))
         self.label['parc'].setText(cap_p_str)
         self.label['parl'].setText(ind_p_str)


### PR DESCRIPTION
Calculates the admittance as 1/Z, checks for Z=0.

Unit is "S" for Siemens as Omega^-1 was running into space issues in the currently available formatting of the marker window

Fixes #445