### PR TITLE
Version: avoid infinite recursion

### DIFF
--- a/NanoVNASaver/Version.py
+++ b/NanoVNASaver/Version.py
@@ -54,13 +54,13 @@ class Version:
         return False
 
     def __lt__(self, other: "Version") -> bool:
-        return other > self
+        return other.__gt__(self)
 
     def __ge__(self, other: "Version") -> bool:
-        return self > other or self == other
+        return self.__gt__(other) or self.__eq__(other)
 
     def __le__(self, other: "Version") -> bool:
-        return self < other or self == other
+        return other.__gt__(self) or self.__eq__(other)
 
     def __eq__(self, other: "Version") -> bool:
         return self.data == other.data


### PR DESCRIPTION
The comparison operators (`<`, `>`, etc.) are not translated 1:1 to customisation methods (`__lt__`, `__gt__`, ...) in Python. Instead the type of the operands plays a role in determining on which of the two sides the customisation method is invoked (see [Python Language Reference section 3.3.1](https://docs.python.org/3/reference/datamodel.html#object.__lt__)). This means `a > b` can end up invoking `b.__lt__(a)` rather than `a.__gt__(b)`.

This behaviour can causes infinite recursion in `Version.__lt__()`:

```
2022-03-07 13:47:52,087 - NanoVNASaver.Hardware.NanoVNA_V2 - ERROR - Timeout reading version registers
Traceback (most recent call last):
  File "/home/sascha/nanovna-saver/NanoVNASaver/Controls/SerialControl.py", line 73, in serialButtonClick
    self.connect_device()
  File "/home/sascha/nanovna-saver/NanoVNASaver/Controls/SerialControl.py", line 93, in connect_device
    self.app.vna = get_VNA(self.interface)
  File "/home/sascha/nanovna-saver/NanoVNASaver/Hardware/Hardware.py", line 101, in get_VNA
    return NAME2DEVICE[iface.comment](iface)
  File "/home/sascha/nanovna-saver/NanoVNASaver/Hardware/NanoVNA_V2.py", line 76, in __init__
    super().__init__(iface)
  File "/home/sascha/nanovna-saver/NanoVNASaver/Hardware/VNA.py", line 71, in __init__
    self.read_features()
  File "/home/sascha/nanovna-saver/NanoVNASaver/Hardware/NanoVNA_V2.py", line 107, in read_features
    if self.board_revision >= Version("2.0.4"):
  File "/home/sascha/nanovna-saver/NanoVNASaver/Version.py", line 63, in __le__
    return self < other or self == other
  File "/home/sascha/nanovna-saver/NanoVNASaver/Version.py", line 57, in __lt__
    return other > self
  File "/home/sascha/nanovna-saver/NanoVNASaver/Version.py", line 57, in __lt__
    return other > self
  File "/home/sascha/nanovna-saver/NanoVNASaver/Version.py", line 57, in __lt__
    return other > self
  [Previous line repeated 491 more times]
RecursionError: maximum recursion depth exceeded in comparison
```

Fix it by explicitly invoking the customisation methods we expect.