### PR TITLE
Cast progress value to integer

### DIFF
--- a/NanoVNASaver/NanoVNASaver.py
+++ b/NanoVNASaver/NanoVNASaver.py
@@ -493,7 +493,7 @@ class NanoVNASaver(QtWidgets.QWidget):
         for c in self.combinedCharts:
             c.setCombinedData(s11, s21)
 
-        self.sweep_control.progress_bar.setValue(self.worker.percentage)
+        self.sweep_control.progress_bar.setValue(int(self.worker.percentage))
         self.windows["tdr"].updateTDR()
 
         if s11:


### PR DESCRIPTION
PyQt5 has changed to hint the progress value to integer, resulting in a
type mismatch and subsequent crash when we're passing a float in. This
is often the case when using more than one segment. Rather than crash,
we should just truncate the progress value to integer.

I've chosen truncation rather than rounding to ensure values like 99.5% are
pessimistically rounded down rather than up, avoiding the false
impression that all sweeps are done.

For reference, the crash bug fixed here normally looks something like this,
occurring just after starting a capture with >1 segments:

```
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/NanoVNASaver/NanoVNASaver.py", line 496, in dataUpdated
    self.sweep_control.progress_bar.setValue(self.worker.percentage)
TypeError: setValue(self, int): argument 1 has unexpected type 'float'
zsh: IOT instruction (core dumped)  NanoVNASaver
```