### PR TITLE
getPlotable, cast return values to int

### DIFF
--- a/NanoVNASaver/Charts/Frequency.py
+++ b/NanoVNASaver/Charts/Frequency.py
@@ -681,9 +681,10 @@ class FrequencyChart(Chart):
         dap = np.array([-da[1], da[0]])
         denom = np.dot(dap, db)
 
-        return (((np.dot(dap, dp) / denom.astype(float)) * db + p3)[:2]
-                if denom
-                else (x, y))
+        if denom:
+            x, y = ((np.dot(dap, dp) / denom.astype(float)) * db + p3)[:2]
+
+        return int(x), int(y)
 
     def copy(self):
         new_chart = super().copy()


### PR DESCRIPTION
Closes #500

NanoVNA-saver crashes per below when getPlotable returns a float.
getPlotable is always followed by a call to drawLine(self, int, int,
int, int), so it needs to return ints.

Cast getPlotable return values to int in all cases.

Traceback (most recent call last):
  File "/home/blinken/co/nanovna-saver/NanoVNASaver/Charts/Frequency.py", line 447, in paintEvent
    self.drawValues(qp)
  File "/home/blinken/co/nanovna-saver/NanoVNASaver/Charts/VSWR.py", line 144, in drawValues
    self.drawData(qp, self.data, Chart.color.sweep)
  File "/home/blinken/co/nanovna-saver/NanoVNASaver/Charts/Frequency.py", line 641, in drawData
    qp.drawLine(prevx, prevy, new_x, new_y)
TypeError: arguments did not match any overloaded call:
  drawLine(self, QLineF): argument 1 has unexpected type 'int'
  drawLine(self, QLine): argument 1 has unexpected type 'int'
  drawLine(self, int, int, int, int): argument 3 has unexpected type 'numpy.float64'
  drawLine(self, QPoint, QPoint): argument 1 has unexpected type 'int'
  drawLine(self, Union[QPointF, QPoint], Union[QPointF, QPoint]): argument 1 has unexpected type 'int'
Aborted