### PR TITLE
Add negative real resistance for proper graph scaling

### DIFF
--- a/NanoVNASaver/Charts/RI.py
+++ b/NanoVNASaver/Charts/RI.py
@@ -183,8 +183,8 @@ class RealImaginaryChart(FrequencyChart):
                     min_imag = im
 
             # Always have at least 8 numbered horizontal lines
-            max_real = max(8, math.ceil(max_real))
-            min_real = max(0, math.floor(min_real))  # Negative real resistance? No.
+            max_real = math.ceil(max_real)
+            min_real = math.floor(min_real)
             max_imag = math.ceil(max_imag)
             min_imag = math.floor(min_imag)
 


### PR DESCRIPTION
I made an inductor that the NanoVNA measures as having a negative real resistance, so the automatic scaling of the plot doesn't work:
![Screenshot from 2022-08-25 19-04-16](https://user-images.githubusercontent.com/22188245/186800939-bc95a0b8-a180-44c9-9dd7-53738d91eda1.png)
Adding this change fixes it so that it does scale properly:
![Screenshot from 2022-08-25 18-55-43](https://user-images.githubusercontent.com/22188245/186800943-52c21c3b-b90c-4830-8b5d-becf4049fa27.png)


