### PR TITLE
Support of NanoVNA V2 Plus5 on Windows (FW 20220814)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,5 +42,5 @@ debinstall: deb
 # uninstall this debian package
 .PHONY: debuninstall
 debuninstall:
-	sudo apt purge nanovnasaver_*.deb
+	sudo apt purge nanovnasaver
 

--- a/NanoVNASaver/Hardware/Hardware.py
+++ b/NanoVNASaver/Hardware/Hardware.py
@@ -70,7 +70,8 @@ NAME2DEVICE = {
 
 
 def _fix_v2_hwinfo(dev):
-    if dev.hwid == r'PORTS\VID_04B4&PID_0008\DEMO':
+    # if dev.hwid == r'PORTS\VID_04B4&PID_0008\DEMO':
+    if r'PORTS\VID_04B4&PID_0008' in dev.hwid:
         dev.vid, dev.pid = 0x04b4, 0x0008
     return dev
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:  NanoVNA V2 Plus5 not recognized on Windows with last FW 20220814.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- VNA appears now as 'COMXX (S-A-A-2)' in the Serial port control section of thr GUI
- Now device can be connected without error
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
