### PR TITLE
dataclass fix for python3.11 compatability

### DIFF
--- a/NanoVNASaver/Charts/Chart.py
+++ b/NanoVNASaver/Charts/Chart.py
@@ -18,11 +18,12 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import logging
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from typing import List, Set, Tuple, ClassVar, Any, Optional
 
 from PyQt5 import QtWidgets, QtGui, QtCore
 from PyQt5.QtCore import pyqtSignal
+from PyQt5.QtGui import QColor
 
 from NanoVNASaver import Defaults
 from NanoVNASaver.RFTools import Datapoint
@@ -33,15 +34,18 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class ChartColors:  # pylint: disable=too-many-instance-attributes
-    background: QtGui.QColor = QtGui.QColor(QtCore.Qt.white)
-    foreground: QtGui.QColor = QtGui.QColor(QtCore.Qt.lightGray)
-    reference: QtGui.QColor = QtGui.QColor(0, 0, 255, 64)
-    reference_secondary: QtGui.QColor = QtGui.QColor(0, 0, 192, 48)
-    sweep: QtGui.QColor = QtGui.QColor(QtCore.Qt.darkYellow)
-    sweep_secondary: QtGui.QColor = QtGui.QColor(QtCore.Qt.darkMagenta)
-    swr: QtGui.QColor = QtGui.QColor(255, 0, 0, 128)
-    text: QtGui.QColor = QtGui.QColor(QtCore.Qt.black)
-    bands: QtGui.QColor = QtGui.QColor(128, 128, 128, 48)
+    background: QColor = field(default_factory=lambda: QColor(QtCore.Qt.white))
+    foreground: QColor = field(
+            default_factory=lambda: QColor(QtCore.Qt.lightGray))
+    reference: QColor = field(default_factory=lambda: QColor(0, 0, 255, 64))
+    reference_secondary: QColor = field(
+        default_factory=lambda: QColor(0, 0, 192, 48))
+    sweep: QColor = field(default_factory=lambda: QColor(QtCore.Qt.darkYellow))
+    sweep_secondary: QColor = field(
+        default_factory=lambda: QColor(QtCore.Qt.darkMagenta))
+    swr: QColor = field(default_factory=lambda: QColor(255, 0, 0, 128))
+    text: QColor = field(default_factory=lambda: QColor(QtCore.Qt.black))
+    bands: QColor = field(default_factory=lambda: QColor(128, 128, 128, 48))
 
 
 @dataclass

--- a/NanoVNASaver/Defaults.py
+++ b/NanoVNASaver/Defaults.py
@@ -68,15 +68,23 @@ class Chart:
 
 @DC.dataclass
 class ChartColors:  # pylint: disable=too-many-instance-attributes
-    background: QColor = QColor(QtCore.Qt.white)
-    foreground: QColor = QColor(QtCore.Qt.lightGray)
-    reference: QColor = QColor(0, 0, 255, 64)
-    reference_secondary: QColor = QColor(0, 0, 192, 48)
-    sweep: QColor = QColor(QtCore.Qt.darkYellow)
-    sweep_secondary: QColor = QColor(QtCore.Qt.darkMagenta)
-    swr: QColor = QColor(255, 0, 0, 128)
-    text: QColor = QColor(QtCore.Qt.black)
-    bands: QColor = QColor(128, 128, 128, 48)
+    background: QColor = DC.field(
+        default_factory=lambda: QColor(QtCore.Qt.white))
+    foreground: QColor = DC.field(
+        default_factory=lambda: QColor(QtCore.Qt.lightGray))
+    reference: QColor = DC.field(default_factory=lambda: QColor(0, 0, 255, 64))
+    reference_secondary: QColor = DC.field(
+        default_factory=lambda: QColor(0, 0, 192, 48))
+    sweep: QColor = DC.field(
+        default_factory=lambda: QColor(QtCore.Qt.darkYellow))
+    sweep_secondary: QColor = DC.field(
+        default_factory=lambda: QColor(QtCore.Qt.darkMagenta))
+    swr: QColor = DC.field(
+        default_factory=lambda: QColor(255, 0, 0, 128))
+    text: QColor = DC.field(
+        default_factory=lambda: QColor(QtCore.Qt.black))
+    bands: QColor = DC.field(
+        default_factory=lambda: QColor(128, 128, 128, 48))
 
 
 @DC.dataclass
@@ -86,23 +94,30 @@ class Markers:
         "vswr", "returnloss", "s11q", "s11phase", "s21gain", "s21phase",
     ])
     colored_names: bool = True
-    color_0: QColor = QColor(QtCore.Qt.darkGray)
-    color_1: QColor = QColor(255, 0, 0)
-    color_2: QColor = QColor(0, 255, 0)
-    color_3: QColor = QColor(0, 0, 255)
-    color_4: QColor = QColor(0, 255, 255)
-    color_5: QColor = QColor(255, 0, 255)
-    color_6: QColor = QColor(255, 255, 0)
-    color_7: QColor = QColor(QtCore.Qt.lightGray)
+    color_0: QColor = DC.field(
+        default_factory=lambda: QColor(QtCore.Qt.darkGray))
+    color_1: QColor = DC.field(default_factory=lambda: QColor(255, 0, 0))
+    color_2: QColor = DC.field(default_factory=lambda: QColor(0, 255, 0))
+    color_3: QColor = DC.field(default_factory=lambda: QColor(0, 0, 255))
+    color_4: QColor = DC.field(default_factory=lambda: QColor(0, 255, 255))
+    color_5: QColor = DC.field(default_factory=lambda: QColor(255, 0, 255))
+    color_6: QColor = DC.field(default_factory=lambda: QColor(255, 255, 0))
+    color_7: QColor = DC.field(
+        default_factory=lambda: QColor(QtCore.Qt.lightGray))
 
 
 @DC.dataclass
 class CFG:
-    gui: object = GUI()
-    charts_selected: object = ChartsSelected()
-    chart: object = Chart()
-    chart_colors: object = ChartColors()
-    markers: object = Markers()
+    gui: object = DC.field(
+        default_factory=lambda: GUI())
+    charts_selected: object = DC.field(
+        default_factory=lambda: ChartsSelected())
+    chart: object = DC.field(
+        default_factory=lambda: Chart())
+    chart_colors: object = DC.field(
+        default_factory=lambda: ChartColors())
+    markers: object = DC.field(
+        default_factory=lambda: Markers())
 
 
 cfg = CFG()

--- a/NanoVNASaver/Windows/DisplaySettings.py
+++ b/NanoVNASaver/Windows/DisplaySettings.py
@@ -350,21 +350,22 @@ class DisplaySettingsWindow(QtWidgets.QWidget):
         self.changeChart(1, 1, chart11_selection.currentText())
         self.changeChart(1, 2, chart12_selection.currentText())
 
+        chart_colors = ChartColors()
         Chart.color.background = self.app.settings.value(
-            "BackgroundColor", defaultValue=ChartColors.background,
+            "BackgroundColor", defaultValue=chart_colors.background,
             type=QtGui.QColor)
         Chart.color.foreground = self.app.settings.value(
-            "ForegroundColor", defaultValue=ChartColors.foreground,
+            "ForegroundColor", defaultValue=chart_colors.foreground,
             type=QtGui.QColor)
         Chart.color.text = self.app.settings.value(
-            "TextColor", defaultValue=ChartColors.text,
+            "TextColor", defaultValue=chart_colors.text,
             type=QtGui.QColor)
         self.bandsColor = self.app.settings.value(
-            "BandsColor", defaultValue=ChartColors.bands,
+            "BandsColor", defaultValue=chart_colors.bands,
             type=QtGui.QColor)
         self.app.bands.color = Chart.color.bands
         Chart.color.swr = self.app.settings.value(
-            "VSWRColor", defaultValue=ChartColors.swr,
+            "VSWRColor", defaultValue=chart_colors.swr,
             type=QtGui.QColor)
 
         self.dark_mode_option.setChecked(Defaults.cfg.gui.dark_mode)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pyserial==3.5
 PyQt5==5.15.7
-numpy==1.23.3
-scipy==1.9.1
+numpy==1.23.5
+scipy==1.9.3
 Cython==0.29.32


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Bugfix

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Dataclasse with QColor objects would only work with a default_factory in Python dataclasses
 
## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
