### PR TITLE
Proposal for #485 - make all windows scrollable

### DIFF
--- a/NanoVNASaver/Windows/About.py
+++ b/NanoVNASaver/Windows/About.py
@@ -37,7 +37,17 @@ class AboutWindow(QtWidgets.QWidget):
         self.setWindowTitle("About NanoVNASaver")
         self.setWindowIcon(self.app.icon)
         top_layout = QtWidgets.QHBoxLayout()
-        self.setLayout(top_layout)
+
+        scrollarea = QtWidgets.QScrollArea()
+        scrollarea.setWidgetResizable(True)
+        outer = QtWidgets.QVBoxLayout()
+        outer.addWidget(scrollarea)
+        widget = QtWidgets.QWidget()
+        widget.setLayout(top_layout)
+        scrollarea.setWidget(widget)
+        self.setLayout(outer)
+        self.resize( scrollarea.size() )
+
         QtWidgets.QShortcut(QtCore.Qt.Key_Escape, self, self.hide)
 
         icon_layout = QtWidgets.QVBoxLayout()

--- a/NanoVNASaver/Windows/AnalysisWindow.py
+++ b/NanoVNASaver/Windows/AnalysisWindow.py
@@ -49,7 +49,16 @@ class AnalysisWindow(QtWidgets.QWidget):
         QtWidgets.QShortcut(QtCore.Qt.Key_Escape, self, self.hide)
 
         layout = QtWidgets.QVBoxLayout()
-        self.setLayout(layout)
+
+        scrollarea = QtWidgets.QScrollArea()
+        scrollarea.setWidgetResizable(True)
+        outer = QtWidgets.QVBoxLayout()
+        outer.addWidget(scrollarea)
+        widget = QtWidgets.QWidget()
+        widget.setLayout(layout)
+        scrollarea.setWidget(widget)
+        self.setLayout(outer)
+        self.resize( scrollarea.size() )
 
         select_analysis_box = QtWidgets.QGroupBox("Select analysis")
         select_analysis_layout = QtWidgets.QFormLayout(select_analysis_box)

--- a/NanoVNASaver/Windows/CalibrationSettings.py
+++ b/NanoVNASaver/Windows/CalibrationSettings.py
@@ -59,7 +59,17 @@ class CalibrationWindow(QtWidgets.QWidget):
         right_layout = QtWidgets.QVBoxLayout()
         top_layout.addLayout(left_layout)
         top_layout.addLayout(right_layout)
-        self.setLayout(top_layout)
+
+        scrollarea = QtWidgets.QScrollArea()
+        scrollarea.setWidgetResizable(True)
+        outer = QtWidgets.QVBoxLayout()
+        outer.addWidget(scrollarea)
+        widget = QtWidgets.QWidget()
+        widget.setLayout(top_layout)
+        scrollarea.setWidget(widget)
+        self.setLayout(outer)
+        self.resize( scrollarea.size() )
+
 
         calibration_status_group = QtWidgets.QGroupBox("Active calibration")
         calibration_status_layout = QtWidgets.QFormLayout()

--- a/NanoVNASaver/Windows/DeviceSettings.py
+++ b/NanoVNASaver/Windows/DeviceSettings.py
@@ -46,7 +46,16 @@ class DeviceSettingsWindow(QtWidgets.QWidget):
         right_layout = QtWidgets.QVBoxLayout()
         top_layout.addLayout(left_layout)
         top_layout.addLayout(right_layout)
-        self.setLayout(top_layout)
+
+        scrollarea = QtWidgets.QScrollArea()
+        scrollarea.setWidgetResizable(True)
+        outer = QtWidgets.QVBoxLayout()
+        outer.addWidget(scrollarea)
+        widget = QtWidgets.QWidget()
+        widget.setLayout(top_layout)
+        scrollarea.setWidget(widget)
+        self.setLayout(outer)
+        self.resize( scrollarea.size() )
 
         status_box = QtWidgets.QGroupBox("Status")
         status_layout = QtWidgets.QFormLayout(status_box)

--- a/NanoVNASaver/Windows/DisplaySettings.py
+++ b/NanoVNASaver/Windows/DisplaySettings.py
@@ -44,7 +44,16 @@ class DisplaySettingsWindow(QtWidgets.QWidget):
         QtWidgets.QShortcut(QtCore.Qt.Key_Escape, self, self.hide)
 
         layout = QtWidgets.QHBoxLayout()
-        self.setLayout(layout)
+
+        scrollarea = QtWidgets.QScrollArea()
+        scrollarea.setWidgetResizable(True)
+        outer = QtWidgets.QVBoxLayout()
+        outer.addWidget(scrollarea)
+        widget = QtWidgets.QWidget()
+        widget.setLayout(layout)
+        scrollarea.setWidget(widget)
+        self.setLayout(outer)
+        self.resize( scrollarea.size() )
 
         left_layout = QtWidgets.QVBoxLayout()
         layout.addLayout(left_layout)

--- a/NanoVNASaver/Windows/Files.py
+++ b/NanoVNASaver/Windows/Files.py
@@ -35,7 +35,16 @@ class FilesWindow(QtWidgets.QWidget):
         self.setMinimumWidth(200)
         QtWidgets.QShortcut(QtCore.Qt.Key_Escape, self, self.hide)
         file_window_layout = QtWidgets.QVBoxLayout()
-        self.setLayout(file_window_layout)
+
+        scrollarea = QtWidgets.QScrollArea()
+        scrollarea.setWidgetResizable(True)
+        outer = QtWidgets.QVBoxLayout()
+        outer.addWidget(scrollarea)
+        widget = QtWidgets.QWidget()
+        widget.setLayout(file_window_layout)
+        scrollarea.setWidget(widget)
+        self.setLayout(outer)
+        self.resize( scrollarea.size() )
 
         load_file_control_box = QtWidgets.QGroupBox("Import file")
         load_file_control_box.setMaximumWidth(300)

--- a/NanoVNASaver/Windows/SweepSettings.py
+++ b/NanoVNASaver/Windows/SweepSettings.py
@@ -40,7 +40,16 @@ class SweepSettingsWindow(QtWidgets.QWidget):
         QtWidgets.QShortcut(QtCore.Qt.Key_Escape, self, self.hide)
 
         layout = QtWidgets.QVBoxLayout()
-        self.setLayout(layout)
+
+        scrollarea = QtWidgets.QScrollArea()
+        scrollarea.setWidgetResizable(True)
+        outer = QtWidgets.QVBoxLayout()
+        outer.addWidget(scrollarea)
+        widget = QtWidgets.QWidget()
+        widget.setLayout(layout)
+        scrollarea.setWidget(widget)
+        self.setLayout(outer)
+        self.resize( scrollarea.size() )
 
         layout.addWidget(self.title_box())
         layout.addWidget(self.settings_box())

--- a/NanoVNASaver/Windows/TDR.py
+++ b/NanoVNASaver/Windows/TDR.py
@@ -84,7 +84,16 @@ class TDRWindow(QtWidgets.QWidget):
         QtWidgets.QShortcut(QtCore.Qt.Key_Escape, self, self.hide)
 
         layout = QtWidgets.QFormLayout()
-        self.setLayout(layout)
+
+        scrollarea = QtWidgets.QScrollArea()
+        scrollarea.setWidgetResizable(True)
+        outer = QtWidgets.QVBoxLayout()
+        outer.addWidget(scrollarea)
+        widget = QtWidgets.QWidget()
+        widget.setLayout(layout)
+        scrollarea.setWidget(widget)
+        self.setLayout(outer)
+        self.resize( scrollarea.size() )
 
         self.tdr_velocity_dropdown = QtWidgets.QComboBox()
         for cable_name, velocity in CABLE_PARAMETERS:


### PR DESCRIPTION

<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #485

@kencormack wrote:
On smaller displays (ie: a 7" 800x480 touchscreen), certain screens, such as the "Display settings" screen, are not downward scroll-able. Consequently, options to select "Displayed charts", "Markers", and such, are not available/cannot be accessed.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- All sub windows can be resized and get scrollbars if too small

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

Example of resized Calibration window:

![image](https://user-images.githubusercontent.com/12542359/215860900-93c51d21-eef1-45bf-a794-64926701fe03.png)
