### PR TITLE
getYPosition fix

### DIFF
--- a/NanoVNASaver/Charts/Frequency.py
+++ b/NanoVNASaver/Charts/Frequency.py
@@ -333,8 +333,8 @@ class FrequencyChart(Chart):
         try:
             return (
                 self.topMargin +
-                round((self.maxValue - self.value_function(d) /
-                       self.span * self.dim.height)))
+                round((self.maxValue - self.value_function(d)) /
+                       self.span * self.dim.height))
         except ValueError:
             return self.topMargin
 


### PR DESCRIPTION
The correct order of parenthesises in the getYPosition() method

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Charts like Serial C and Serial L are broken due to a bug/typo in the logic computing vertical chart position. Serial C does not show anything and Serial L in inverted.

Issue Number: N/A

## What is the new behavior?
Charts show correct L and C

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
