### PR TITLE
__main__.py: remove /bin/env shebang

### DIFF
--- a/src/NanoVNASaver/__main__.py
+++ b/src/NanoVNASaver/__main__.py
@@ -1,5 +1,3 @@
-#! /bin/env python
-#
 #  NanoVNASaver
 #
 #  A python program to view and export Touchstone data from a NanoVNA


### PR DESCRIPTION
The file is not intended for direct execution,
not installed in the path,
and not marked as executable.
Its extension is sufficient for editors to trigger syntax highlighting.

The shebang seems to only trigger warnings on systems wher /bin/env is unavailable (it may be in /usr/bin for example).

Code style update

Not a breaking change?
