### PR TITLE
fix: sweep settings and hw version update

### DIFF
--- a/src/NanoVNASaver/Hardware/NanoVNA_V2.py
+++ b/src/NanoVNASaver/Hardware/NanoVNA_V2.py
@@ -85,7 +85,7 @@ class NanoVNA_V2(VNA):
             sleep(WRITE_SLEEP)
 
         # firmware major version of 0xff indicates dfu mode
-        if self.version.data["major"] == 0xFF:
+        if self.version.major == 0xFF:
             raise IOError("Device is in DFU mode")
 
         if "S21 hack" in self.features:

--- a/src/NanoVNASaver/Settings/Sweep.py
+++ b/src/NanoVNASaver/Settings/Sweep.py
@@ -32,7 +32,7 @@ class SweepMode(Enum):
     AVERAGE = 2
 
 
-class Properties(NamedTuple):
+class Properties:
     name: str = ""
     mode: "SweepMode" = SweepMode.SINGLE
     averages: tuple[int, int] = (3, 0)


### PR DESCRIPTION
NamedTuples are immutable either use _replace or use the class itself.

## Pull Request type

- Single

Please check the type of change your PR introduces:

- [X ] Bugfix

## What is the current behavior?

- Bug updating sweep.properties value
- Bug updating VNA.version value

## What is the new behavior?

- Sweep settings now work as expected.
- Hardware LiteVNA64 hardware is now properly initialized 

## Does this introduce a breaking change?

- [X ] No

## Other information

Apparently python 3.10 is more strict in checking immutable states
The NanoVNA_V2.py driver was probably missed by an update.

