### PR TITLE
nanovna-saver.py: fix execution from outside source directory

### DIFF
--- a/nanovna-saver.py
+++ b/nanovna-saver.py
@@ -17,6 +17,7 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from contextlib import suppress
+import os
 
 # noinspection PyUnresolvedReferences
 with suppress(ImportError):
@@ -29,7 +30,7 @@ try:
 except ModuleNotFoundError:
     import sys
 
-    sys.path.append("src")
+    sys.path.append(os.path.join(os.path.dirname(__file__), "src"))
     from NanoVNASaver.__main__ import main
 
 


### PR DESCRIPTION
nanovna-saver.py can be called from outside the source directory. The module import path needs to be resolved relative to the source directory, not relative to the current working directory of the process.

Fixes: b0110002 ("moved to pyscaffold directory structure")

This branch is based on the commit before the transition to PyQt6 as the latter is not available in Debian stable (Bullseye).

<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

When executing `nanovna-saver.py` from outside the source directory but without installing it, importing `main` fails:

```
I have no name!@nanovna:~/nanovna-data$ cd ~/nanovna-data && python3 ~/nanovna-saver/nanovna-saver.py -d
Traceback (most recent call last):
  File "/home/sascha/nanovna-saver/nanovna-saver.py", line 29, in <module>
    from NanoVNASaver.__main__ import main
ModuleNotFoundError: No module named 'NanoVNASaver.__main__'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/sascha/nanovna-saver/nanovna-saver.py", line 35, in <module>
    from NanoVNASaver.__main__ import main
ModuleNotFoundError: No module named 'NanoVNASaver.__main__'
```

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

Running `nanovna-saver.py` from outside the source directory (but without installing it first) works again.
<!-- Please describe the behavior or changes that are being added by this PR. -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
