### PR TITLE
fix "Could not parse stylesheet of object QGroupBox..." error

### DIFF
--- a/src/NanoVNASaver/Marker/Widget.py
+++ b/src/NanoVNASaver/Marker/Widget.py
@@ -183,10 +183,8 @@ class Marker(QtCore.QObject, Value):
         self.label["actualfreq"].setMinimumWidth(int(100 * scale))
         self.label["returnloss"].setMinimumWidth(int(80 * scale))
         if self.coloredText:
-            color_string = QtCore.QVariant(self.color)
-            #            color_string.convert(QtCore.QVariant.String)
             self.group_box.setStyleSheet(
-                f"QGroupBox {{ color: {color_string.value()}; "
+                f"QGroupBox {{ color: {self.color.name()}; "
                 f"font-size: {self._size_str()}}};"
             )
         else:
@@ -233,11 +231,9 @@ class Marker(QtCore.QObject, Value):
             p = self.btnColorPicker.palette()
             p.setColor(QtGui.QPalette.ColorRole.ButtonText, self.color)
             self.btnColorPicker.setPalette(p)
-        # TODO: fix Stylesheet
         if self.coloredText:
-            color_string = QtCore.QVariant(color)
             self.group_box.setStyleSheet(
-                f"QGroupBox {{ color: {color_string.value()}; "
+                f"QGroupBox {{ color: {color.name()}; "
                 f"font-size: {self._size_str()}}};"
             )
         else:

--- a/src/NanoVNASaver/Windows/DisplaySettings.py
+++ b/src/NanoVNASaver/Windows/DisplaySettings.py
@@ -551,6 +551,7 @@ class DisplaySettingsWindow(QtWidgets.QWidget):
             logger.info("Invalid color")
             return
 
+        setattr( Chart.color, attr, color ) # update trace color immediately
         palette = sender.palette()
         palette.setColor(QPalette.ColorRole.ButtonText, color)
         sender.setPalette(palette)


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

At program start many error messages are written on terminal:
`Could not parse stylesheet of object QGroupBox...`
Header lines of marker boxes are not colored.

Sweep color does not change without close/re-open (#596)

## What is the new behavior?

No error messages, colored header lines of marker boxes (commit 1)
Fix #596: Update sweep color immediately when changed in display settings (commit 2)

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

