### PR TITLE
option --auto-connect, connect automatically if one device detected

### DIFF
--- a/src/NanoVNASaver/NanoVNASaver.py
+++ b/src/NanoVNASaver/NanoVNASaver.py
@@ -473,8 +473,8 @@ class NanoVNASaver(QWidget):
 
         logger.debug("Finished building interface")
 
-    def auto_connect( self ): # connect to the 1st detected serial device
-        if self.serial_control.inp_port.currentData():
+    def auto_connect( self ): # connect if there is exactly one detected serial device
+        if self.serial_control.inp_port.count() == 1:
             self.serial_control.connect_device()
 
     def _sweep_control(self, start: bool = True) -> None:

--- a/src/NanoVNASaver/NanoVNASaver.py
+++ b/src/NanoVNASaver/NanoVNASaver.py
@@ -473,6 +473,10 @@ class NanoVNASaver(QWidget):
 
         logger.debug("Finished building interface")
 
+    def auto_connect( self ): # connect to the 1st detected serial device
+        if self.serial_control.inp_port.currentData():
+            self.serial_control.connect_device()
+
     def _sweep_control(self, start: bool = True) -> None:
         self.sweep_control.progress_bar.setValue(0 if start else 100)
         self.sweep_control.btn_start.setDisabled(start)

--- a/src/NanoVNASaver/__main__.py
+++ b/src/NanoVNASaver/__main__.py
@@ -47,6 +47,9 @@ def main():
         "-D", "--debug-file", help="File to write debug logging output to"
     )
     parser.add_argument(
+        "-a", "--auto-connect", action="store_true", help="Auto connect to detected 1st device"
+    )
+    parser.add_argument(
         "-f",
         "--file",
         help="Touchstone file to load as sweep for off" " device usage",
@@ -92,6 +95,8 @@ def main():
     window = NanoVNASaver()
     window.show()
 
+    if args.auto_connect:
+        window.auto_connect()
     if args.file:
         t = Touchstone(args.file)
         t.load()

--- a/src/NanoVNASaver/__main__.py
+++ b/src/NanoVNASaver/__main__.py
@@ -47,7 +47,7 @@ def main():
         "-D", "--debug-file", help="File to write debug logging output to"
     )
     parser.add_argument(
-        "-a", "--auto-connect", action="store_true", help="Auto connect to detected 1st device"
+        "-a", "--auto-connect", action="store_true", help="Auto connect if one device detected"
     )
     parser.add_argument(
         "-f",


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the new behavior?

Command line option `--auto-connect` or `-a` connects automatically if one device was detected - useful in most cases where you have only one NanoVNA connected to the PC. If there are more NanoNVAs or a NanoNVA and a tinySA connected, the user has to select from the combo list.
 
## Does this introduce a breaking change?

- [ ] Yes
- [X] No

