### PR TITLE
Adapt sweep settings imports and tests to source changes

### DIFF
--- a/src/NanoVNASaver/Settings/Sweep.py
+++ b/src/NanoVNASaver/Settings/Sweep.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass, replace
 from enum import Enum
 from math import log
 from threading import Lock
-from typing import Iterator, NamedTuple
+from typing import Iterator
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -19,18 +19,24 @@
 import unittest
 
 # Import targets to be tested
-from NanoVNASaver.Settings.Sweep import Sweep, Properties
+from NanoVNASaver.Settings.Sweep import Sweep, Properties, SweepMode
 
 
 class TestCases(unittest.TestCase):
 
     def test_sweep(self):
         sweep = Sweep()
-        self.assertEqual(str(sweep),
-                         "Sweep(start=3600000, end=30000000, points=101,"
-                         " segments=1, properties=Properties(name='',"
-                         " mode=<SweepMode.SINGLE: 0>, averages=(3, 0),"
-                         " logarithmic=False))")
+        self.assertEqual(sweep.start, 3600000)
+        self.assertEqual(sweep.end, 30000000)
+        self.assertEqual(sweep.points, 101)
+        self.assertEqual(sweep.segments, 1)
+
+        properties = sweep.properties
+        self.assertEqual(properties.name, '')
+        self.assertEqual(properties.mode, SweepMode.SINGLE)
+        self.assertEqual(properties.averages, (3, 0))
+        self.assertFalse(properties.logarithmic)
+
         self.assertTrue(Sweep(3600000) == sweep)
         self.assertFalse(Sweep(3600001) == sweep)
         self.assertRaises(ValueError, Sweep, -1)


### PR DESCRIPTION
6eb24f23 from merge request 625
made NamedTuple an ancestor of Properties, adapting the imports and tests.

d09b55e1 from merge request 628
removed it but forgot to remove the related changes.

## Pull Request type

- [ x] Bugfix
- [ ] Feature
- [ x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Does this introduce a breaking change?

- [ ] Yes
- [ x] No
