### PR TITLE
Simplify the in-source launcher script

### DIFF
--- a/nanovna-saver.py
+++ b/nanovna-saver.py
@@ -16,23 +16,23 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from contextlib import suppress
-import os
+# This launcher is ignored by setuptools.  Its only purpose is direct
+# execution from a source tree.
 
-# noinspection PyUnresolvedReferences
-with suppress(ImportError):
-    # pylint: disable=no-name-in-module,import-error,unused-import
-    # pyright: reportMissingImports=false
-    import pkg_resources.py2_warn
+import os.path
+import sys
 
-try:
-    from NanoVNASaver.__main__ import main
-except ModuleNotFoundError:
-    import sys
+# Ignore the current working directory.
+src = os.path.join(os.path.dirname(__file__), "src")
 
-    sys.path.append(os.path.join(os.path.dirname(__file__), "src"))
-    from NanoVNASaver.__main__ import main
+# Ignore previously installed versions.
+sys.path.insert(0, src)
+assert os.path.exists(src)
 
+# pylint: disable-next=wrong-import-position
+import NanoVNASaver.__main__
 
-if __name__ == "__main__":
-    main()
+# The traditional test does not make sense here.
+assert __name__ == '__main__'
+
+NanoVNASaver.__main__.main()


### PR DESCRIPTION
The nanovna-saver.py script is ignored by setup.cfg, its only purpose is to test the version in the source directory.

According to https://setuptools.pypa.io/en/latest/history.html, pkg_resources.py2warn has been removed from setuptools in 2020

- [ ] Code style update (formatting, renaming)
## Does this introduce a breaking change?
- [ ] No
