### PR TITLE
With current firmware, the JNCRadio, SV4401A, SV6301A devices allows 1001 datapoints

### DIFF
--- a/src/NanoVNASaver/Hardware/JNCRadio_VNA_3G.py
+++ b/src/NanoVNASaver/Hardware/JNCRadio_VNA_3G.py
@@ -31,8 +31,9 @@ class JNCRadio_VNA_3G(NanoVNA):
     name = "JNCRadio_VNA_3G"
     screenwidth = 800
     screenheight = 480
-    valid_datapoints = (101, 201, 301, 401, 501)
-    sweep_points_max = 501
+    valid_datapoints = (501, 11, 101, 1001)
+    sweep_points_max = 11
+    sweep_points_max = 1001
 
     def __init__(self, iface: Interface):
         super().__init__(iface)
@@ -40,6 +41,7 @@ class JNCRadio_VNA_3G(NanoVNA):
 
     def getScreenshot(self) -> QPixmap:
         logger.debug("Capturing screenshot...")
+        self.serial.timeout=8
         if not self.connected():
             return QPixmap()
         try:

--- a/src/NanoVNASaver/Hardware/JNCRadio_VNA_3G.py
+++ b/src/NanoVNASaver/Hardware/JNCRadio_VNA_3G.py
@@ -32,7 +32,7 @@ class JNCRadio_VNA_3G(NanoVNA):
     screenwidth = 800
     screenheight = 480
     valid_datapoints = (501, 11, 101, 1001)
-    sweep_points_max = 11
+    sweep_points_min = 11
     sweep_points_max = 1001
 
     def __init__(self, iface: Interface):

--- a/src/NanoVNASaver/Hardware/SV4401A.py
+++ b/src/NanoVNASaver/Hardware/SV4401A.py
@@ -31,9 +31,9 @@ class SV4401A(NanoVNA):
     name = "SV4401A"
     screenwidth = 1024
     screenheight = 600
-    valid_datapoints = (101, 301, 501)
-    sweep_points_max = 101
-    sweep_points_max = 501
+    valid_datapoints = (501, 101, 1001)
+    sweep_points_min = 101
+    sweep_points_max = 1001
 
     def __init__(self, iface: Interface):
         super().__init__(iface)

--- a/src/NanoVNASaver/Hardware/SV6301A.py
+++ b/src/NanoVNASaver/Hardware/SV6301A.py
@@ -31,9 +31,9 @@ class SV6301A(NanoVNA):
     name = "SV6301A"
     screenwidth = 1024
     screenheight = 600
-    valid_datapoints = (101, 301, 501)
-    sweep_points_max = 101
-    sweep_points_max = 501
+    valid_datapoints = (501, 101, 1001)
+    sweep_points_min = 101
+    sweep_points_max = 1001
 
     def __init__(self, iface: Interface):
         super().__init__(iface)

--- a/src/NanoVNASaver/Windows/DeviceSettings.py
+++ b/src/NanoVNASaver/Windows/DeviceSettings.py
@@ -152,6 +152,7 @@ class DeviceSettingsWindow(QtWidgets.QWidget):
 
         if "Customizable data points" in features:
             self.datapoints.clear()
+            self.custom_points_Eidt.setValidator(QIntValidator(self.app.vna.sweep_points_min,self.app.vna.sweep_points_max))
             cur_dps = self.app.vna.datapoints
             for d in sorted(self.app.vna.valid_datapoints):
                 self.datapoints.addItem(str(d))


### PR DESCRIPTION
Updated datapoints dropdown to now show only their respective minimums, the 'typical' 101, device default 501 and maximum 1001 points. Users may choose any other values between min and max not seen in the dropdown list using the custom datapoints option.

These devices now use their factory default 501 datapoints as their initial datapoints value.

<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #661

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
