### PR TITLE
Add the nanosaver project icon to resulting Windows application.

### DIFF
--- a/.github/workflows/release_win.yml
+++ b/.github/workflows/release_win.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Build binary
       run: |
         python setup.py -V
-        pyinstaller --onefile -p src -n nanovna-saver.exe nanovna-saver.py
+        pyinstaller --onefile -i icon_48x48.ico -p src -n nanovna-saver.exe nanovna-saver.py
 
     - name: Archive production artifacts
       uses: actions/upload-artifact@v1


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Added -i icon_48x48.ico to the release_win.yml github action.

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Up to now, the nanovna-saver.exe Windows application gets created with a generic python application icon. This change should allow pyinstaller to pick up the the icon_48x48.ico file recently added.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #670 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [X ] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
