### PR TITLE
FIX build for Windows executable

### DIFF
--- a/.github/workflows/release_win.yml
+++ b/.github/workflows/release_win.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.11
+        python-version: 3.12
         architecture: ${{ matrix.arch }}
     - name: Install dependencies and pyinstall
       run: |
@@ -30,8 +30,8 @@ jobs:
         python3 -m pip install -U setuptools setuptools-scm
         python3 -m pip install -r requirements.txt
         python3 -m pip install PyInstaller==6.3.0
-        python3 -m pip uninstall -y PyQt6-sip
-        python3 -m pip install PyQt6-sip==13.6.0
+        python3 -m pip install -U PyQt6-sip
+        python3 -m pip install -U PyQt6
     - name: Build binary
       run: |
         .\venv\Scripts\activate


### PR DESCRIPTION
When I build (for Windows) the version from commit `a04d6d9b3995eabe26a41c9d5abc56678dd8b035` the final executable show the follow error if you try to execute:

```txt
Traceback (most recent call last):
  File "nanovna-saver.py", line 32, in <module>
  File "PyInstaller\loader\pyimod02_importers.py", line 419, in exec_module
  File "NanoVNASaver\__main__.py", line 31, in <module>
ModuleNotFoundError: No module named 'PyQt6.sip'
```

With this changes on build, the `pyinstaller` find correctly the Qt6 dependency and link on the final executable. 

## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

`pyinstaller` build the executable, but can't correct link the PyQt6.sip dependency.

Issue Number: 1

## What is the new behavior?

`pyinstaller` find PyQt6.sip and Qt6 dependency, correctly.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This change only affects the Windows compilation, may be useful for Linux and MacOS, when it was in interest to FIX their build.
