### PR TITLE
Fix frequency calculation at logscale sweeps

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -41,3 +41,4 @@ Contributors
 * sysjoint-tek <63992872+sysjoint-tek@users.noreply.github.com>
 * Thomas de Lellis <24543390+t52ta6ek@users.noreply.github.com>
 * zstadler <zeev.stadler@gmail.com>
+* Peter Hackenberg <170885528+Peter3579@users.noreply.github.com>

--- a/src/NanoVNASaver/Settings/Sweep.py
+++ b/src/NanoVNASaver/Settings/Sweep.py
@@ -18,7 +18,7 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import logging
 from enum import Enum
-from math import log
+from math import exp, log
 from threading import Lock
 from typing import Iterator, NamedTuple
 
@@ -145,12 +145,12 @@ class Sweep:
             raise ValueError(f"Illegal sweep settings: {self}")
 
     def _exp_factor(self, index: int) -> float:
-        return 1 - log(self.segments + 1 - index) / log(self.segments + 1)
+        return exp(log((self.start + self.span)/self.start) / self.segments * index)
 
     def get_index_range(self, index: int) -> tuple[int, int]:
         if self.properties.logarithmic:
-            start = round(self.start + self.span * self._exp_factor(index))
-            end = round(self.start + self.span * self._exp_factor(index + 1))
+            start = round(self.start * self._exp_factor(index))
+            end = round(self.start * self._exp_factor(index + 1))
         else:
             start = self.start + index * self.points * self.stepsize
             end = start + (self.points - 1) * self.stepsize
@@ -160,7 +160,7 @@ class Sweep:
     def get_frequencies(self) -> Iterator[int]:
         for i in range(self.segments):
             start, stop = self.get_index_range(i)
-            step = (stop - start) / self.points
+            step = (stop - start) / (self.points - 1)
             freq = start
             for _ in range(self.points):
                 yield round(freq)

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -44,12 +44,12 @@ class TestCases(unittest.TestCase):
         self.assertEqual(sweep.get_index_range(1), (12429117, 21170817))
         data = list(sweep.get_frequencies())
         self.assertEqual(data[0], 3600000)
-        self.assertEqual(data[-1], 29913383)
+        self.assertEqual(data[-1], 29999934) # should be close to 30000000
         sweep = Sweep(segments=3, properties=Properties(logarithmic=True))
-        self.assertEqual(sweep.get_index_range(1), (9078495, 16800000))
+        self.assertEqual(sweep.get_index_range(1), (7298642, 14797272))
         data = list(sweep.get_frequencies())
         self.assertEqual(data[0], 3600000)
-        self.assertEqual(data[-1], 29869307)
+        self.assertEqual(data[-1], 30000000)
 
         sweep2 = sweep.copy()
         self.assertEqual(sweep, sweep2)


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

In case that `logarithmic sweep` is enabled in the sweep settings, the (internally linearly sampled) segments of 101 data points do not have a proper logarithmic spacing. When multiple segments are used, the quotient of end_frequency by start_frequency for all segments should be the same. Also a small error in the get_frequency() iterator is fixed.

See also:  https://github.com/NanoVNA-Saver/nanovna-saver/issues/701

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [] Feature
- [] Code style update (formatting, renaming)
- [] Refactoring (no functional changes, no API changes)
- [] Build-related changes
- [] Documentation content changes
- [] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In case that `logarithmic sweep` is enabled in the sweep settings, the (internally linearly sampled) segments of 101 data points do not have a proper logarithmic spacing.

https://github.com/NanoVNA-Saver/nanovna-saver/issues/701

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Frequencies with the correct spacing are calculated.

## Does this introduce a breaking change?

- [] Yes
- [X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
