### PR TITLE
Fix a core dump on startup and warning on rexexp search for version number

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -58,11 +58,11 @@ or
 
 `make rpm` builds an (untested) rpm package that can be installed on your system the usual way.
 
-## Ubuntu 20.04 / 22.04
+## Ubuntu 20.04 / 22.04 / 24.04
 
 1. Install python3 and pip
 
-        sudo apt install python3 python3-pip
+        sudo apt install python3 python3-pip libxcb-cursor-dev
         python3 -m venv ~/.venv_nano
         . ~/.venv_nano/bin/activate
         pip install -U pip

--- a/src/NanoVNASaver/Windows/About.py
+++ b/src/NanoVNASaver/Windows/About.py
@@ -146,7 +146,7 @@ class AboutWindow(QtWidgets.QWidget):
                 line = line.decode("utf-8")
                 found_latest_version = TAGS_KEY in line
                 if found_latest_version:
-                    latest_version = Version(re.search("(\\d+\\.\\d+\\.\\d+)", line).group())
+                    latest_version = Version(re.search(r"(\d+\.\d+\.\d+)", line).group())
                     break
         except error.HTTPError as e:
             logger.exception(

--- a/src/NanoVNASaver/Windows/About.py
+++ b/src/NanoVNASaver/Windows/About.py
@@ -146,7 +146,7 @@ class AboutWindow(QtWidgets.QWidget):
                 line = line.decode("utf-8")
                 found_latest_version = TAGS_KEY in line
                 if found_latest_version:
-                    latest_version = Version(re.search("(\d+\.\d+\.\d+)", line).group())
+                    latest_version = Version(re.search("(\\d+\\.\\d+\\.\\d+)", line).group())
                     break
         except error.HTTPError as e:
             logger.exception(


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [] Feature
- [] Code style update (formatting, renaming)
- [] Refactoring (no functional changes, no API changes)
- [] Build-related changes
- [X] Documentation content changes
- [] Other (please describe):

## What is the current behavior?

Performed a virgin install of Lubuntu 24.04 LTS and followed the steps in INSTALLATION.md to create the python3 virtual environment.  Starting nanovna-saver app resulted in core dump. Seems the culprit is a missing installation of libxcb-cursur-dev. Once that installed, nanovna-saver app start and runs.

Notices a warning in checking for updates. Fixed my regexp search as well. 

Issue Number: N/A

## What is the new behavior?

Application run starts up and runs without core dumping or emitting warning about regexp.

-
-
-

## Does this introduce a breaking change?

- [] Yes
- [X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
