### PR TITLE
Fix About.py bug and fix math for TDR

### DIFF
--- a/src/NanoVNASaver/About.py
+++ b/src/NanoVNASaver/About.py
@@ -19,7 +19,7 @@
 
 from setuptools_scm import get_version
 try:
-    version = get_version(root='..', relative_to=__file__)
+    version = get_version(root='../..', relative_to=__file__)
 except LookupError:
     from NanoVNASaver._version import version
 


### PR DESCRIPTION
There is a bug with About.py which results in the program not being able to run if you call `python nanovna_saver.py`. The bug is caused by the path for setuptools-scm not being correctly defined. The path should be `../..` because the .git folder is two directories below, not `..`

There is also a bug with the math for TDR. In the current state, the TDR is not able to distinguish between open and short. In the new code, the TDR is now able to calculate impedance.

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [*] Bugfix
- [] Feature
- [] Code style update (formatting, renaming)
- [] Refactoring (no functional changes, no API changes)
- [] Build-related changes
- [] Documentation content changes
- [] Other (please describe):

## What is the current behavior?

For the About.py bug: a LookupError is thrown by setuptools-scm.

For the TDR bug:
I am using a LiteVNA with a frequency span of 50kHz - 8 GHz. The same calibration was used for every test.

Here is the original software measuring an open transmission line:
![image](https://github.com/user-attachments/assets/1789cc17-3c1b-48b8-bdde-dca01a53cf30)

Here is the original software measuring a short transmission line:
![image](https://github.com/user-attachments/assets/5848675d-71b6-4bf6-8f96-3abbd48d175d)

As you can see the graphs are literally the same, even though the impedance should be zero for the short and infinity for the open.

Here are the other two tests done below:
Terminated:
![image](https://github.com/user-attachments/assets/8dba06c7-9e4f-4d75-acc0-f0de6aa4bea2)

3dB attenuator:
![image](https://github.com/user-attachments/assets/e7347104-f862-4ff1-9d60-69078a19f3e1)

Obviously the terminated plot should be flat and around 50 ohms, but that doesn't seem to be true. The 3dB attenuator should be around 131 ohms (according to my multimeter).

## What is the new behavior?

Open Tline:
![image](https://github.com/user-attachments/assets/e393434c-bb05-4afe-bdda-ef6bd16ba25f)

Shorted Tline:
![image](https://github.com/user-attachments/assets/2d085fc0-7629-42e4-a514-eb9da81d309b)

Terminated Tline:
![image](https://github.com/user-attachments/assets/6e551f07-60e4-4521-b14e-fc552083c82e)

Tline terminated in 3dB attenuator (measures 131 ohms at DC)
![image](https://github.com/user-attachments/assets/b62cd6d5-b99a-4490-92b7-ec8bc147a53a)


## Does this introduce a breaking change?

- [] Yes
- [*] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

The current code plots the magnitude of the impedance. Future updates might allow the user to plot the impedance in mag/ang or real/imag. It might also be a good idea to let the user set the scale for TDR measurements, instead of automatically setting it to 1000