### PR TITLE
Fix TDR math again

### DIFF
--- a/src/NanoVNASaver/Charts/TDR.py
+++ b/src/NanoVNASaver/Charts/TDR.py
@@ -175,21 +175,33 @@ class TDRChart(Chart):
 
     def _configureGraphFromFormat(self):
         TDR_format = self.tdrWindow.format_dropdown.currentText()
-        if TDR_format == "|Z|":
+        if TDR_format == "|Z| (lowpass)":
             self.minYlim = MIN_IMPEDANCE
             self.maxYlim = MAX_IMPEDANCE
             self.formatString = "impedance (\N{OHM SIGN})"
             self.decimals = 1
-        elif TDR_format == "S11":
+        elif TDR_format == "S11 (lowpass)":
             self.minYlim = MIN_S11
             self.maxYlim = MAX_S11
             self.formatString = "S11 (dB)"
             self.decimals = 1
-        elif TDR_format == "VSWR":
+        elif TDR_format == "VSWR (lowpass)":
             self.minYlim = MIN_VSWR
             self.maxYlim = MAX_VSWR
             self.formatString = "VSWR"
             self.decimals = 2
+        elif TDR_format == "Refl (lowpass)":
+            self.minYlim = -1
+            self.maxYlim = 1
+            self.formatString = "U"
+            self.decimals = 2
+        elif TDR_format == "Refl (bandpass)":
+            self.minYlim = 0
+            self.maxYlim = 1
+            self.formatString = "U"
+            self.decimals = 2
+        
+        
 
     def resetDisplayLimits(self):
         self._configureGraphFromFormat()


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [*] Bugfix
- [*] Feature
- [] Code style update (formatting, renaming)
- [] Refactoring (no functional changes, no API changes)
- [] Build-related changes
- [] Documentation content changes
- [] Other (please describe):

## What is the current behavior?

One of the bugs is that if the length to a discontinuity is small, the TDR does not measure correctly. This is because the impulse response looks like a pulse, and half of the pulse is not integrated because it is centered around zero, and only positive time values are added. I solved this issue by also adding the negative time values. This way, the entire pulse is integrated and we get a step response of 1 instead of 0.5. Normally, the negative time values are very small so it doesn't seem like any bad behavior happens from doing this.

Here's what it looks like before, with an open/short discontinuity that is right at the connector:

![image](https://github.com/user-attachments/assets/a1150345-e8de-4cb6-8c13-111881d0a8ec)
![image](https://github.com/user-attachments/assets/af2f00f9-d316-47fc-a2d3-f30d0b88a86d)

## What is the new behavior?

After changing it, I get these plots:

![image](https://github.com/user-attachments/assets/9000c7df-12f8-4911-89d2-ac2d32f8b994)

![image](https://github.com/user-attachments/assets/1a6d1890-8d9b-4867-a8f3-f4d3c8c7cf11)

The load seems good:

![image](https://github.com/user-attachments/assets/b9f85480-a9d0-4731-b967-e9ced8679ad5)

I also added a new feature. It turns out that the old TDR code was partially right, and it implemented something called "bandpass TDR" which is useful for measuring waveguides. Because waveguides have a cutoff frequency, you can't measure the return loss below the cutoff. The current TDR implementation does "lowpass TDR", where you have the entire frequency range from DC to the limit of your VNA. The limitation is that with bandpass TDR, you can only measure the magnitude of the impulse response.

Here is the new feature in action. 

The DUT is a transmission line which is open at one end. The VNA is sweeping from 5GHz to 8GHz.

With lowpass mode, you can see the impedance is completely wrong:

![image](https://github.com/user-attachments/assets/cbddabaa-0f37-4c48-8a59-6c194cd0a4a8)

The bandpass mode shows the correct reflection response. I think the peak is a bit below 1 because of cable loss.

![image](https://github.com/user-attachments/assets/65771479-207f-4cc8-a357-723d695cd696)

Just like with traditional TDR methods, 1 means complete reflection. 

![image](https://github.com/user-attachments/assets/4959c4f8-d9d8-4e39-b182-fbd8eeaadd41)


## Does this introduce a breaking change?

- [] Yes
- [*] No


## Other information

You can read more about the differences between bandpass and lowpass TDR here: https://coppermountaintech.com/wp-content/uploads/2020/01/Time-Domain-Analysis-final.pdf