### PR TITLE
Allow Touchstone files for calibration

### DIFF
--- a/src/NanoVNASaver/Calibration.py
+++ b/src/NanoVNASaver/Calibration.py
@@ -337,7 +337,6 @@ class Calibration:
         cal.e10e01 = cal.e00 * cal.e11 - cal.delta_e
         cal.e22 = gm7 / (gm7 * cal.e11 * gt**2 + cal.e10e01 * gt**2)
         cal.e10e32 = (gm4 - gm6) * (1 - cal.e11 * cal.e22 * gt**2) / gt
-        
 
     def calc_corrections(self):
         if not self.isValid1Port():
@@ -400,7 +399,7 @@ class Calibration:
 
     def gamma_open(self, freq: int) -> complex:
         if self.cal_element.open_state == "IDEAL":
-            return IDEAL_SHORT
+            return IDEAL_OPEN
         if self.cal_element.open_state == "FILE":
             self.cal_element.open_touchstone.gen_interpolation_s11()
             dp = self.cal_element.open_touchstone.s_freq("11", freq)
@@ -425,7 +424,7 @@ class Calibration:
 
     def gamma_load(self, freq: int) -> complex:
         if self.cal_element.load_state == "IDEAL":
-            return IDEAL_SHORT
+            return IDEAL_LOAD
         if self.cal_element.load_state == "FILE":
             self.cal_element.load_touchstone.gen_interpolation_s11()
             dp = self.cal_element.load_touchstone.s_freq("11", freq)
@@ -455,8 +454,7 @@ class Calibration:
         cal_element = self.cal_element
         return cmath.exp(
             complex(0.0, -2.0 * math.pi * cal_element.through_length * freq)
-        )
-    
+        )    
 
     def gen_interpolation(self):
         (freq, e00, e11, delta_e, e10e01, e30, e22, e10e32) = zip(

--- a/src/NanoVNASaver/Calibration.py
+++ b/src/NanoVNASaver/Calibration.py
@@ -337,6 +337,7 @@ class Calibration:
         cal.e10e01 = cal.e00 * cal.e11 - cal.delta_e
         cal.e22 = gm7 / (gm7 * cal.e11 * gt**2 + cal.e10e01 * gt**2)
         cal.e10e32 = (gm4 - gm6) * (1 - cal.e11 * cal.e22 * gt**2) / gt
+        
 
     def calc_corrections(self):
         if not self.isValid1Port():
@@ -368,8 +369,12 @@ class Calibration:
         logger.debug("Calibration correctly calculated.")
 
     def gamma_short(self, freq: int) -> complex:
-        if self.cal_element.short_is_ideal:
+        if self.cal_element.short_state == "IDEAL":
             return IDEAL_SHORT
+        if self.cal_element.short_state == "FILE":
+            self.cal_element.short_touchstone.gen_interpolation_s11()
+            dp = self.cal_element.short_touchstone.s_freq("11", freq)
+            return complex(dp.re, dp.im)
         logger.debug("Using short calibration set values.")
         cal_element = self.cal_element
         Zsp = complex(
@@ -394,8 +399,12 @@ class Calibration:
         )
 
     def gamma_open(self, freq: int) -> complex:
-        if self.cal_element.open_is_ideal:
-            return IDEAL_OPEN
+        if self.cal_element.open_state == "IDEAL":
+            return IDEAL_SHORT
+        if self.cal_element.open_state == "FILE":
+            self.cal_element.open_touchstone.gen_interpolation_s11()
+            dp = self.cal_element.open_touchstone.s_freq("11", freq)
+            return complex(dp.re, dp.im)
         logger.debug("Using open calibration set values.")
         cal_element = self.cal_element
         Zop = complex(
@@ -415,8 +424,12 @@ class Calibration:
         )
 
     def gamma_load(self, freq: int) -> complex:
-        if self.cal_element.load_is_ideal:
-            return IDEAL_LOAD
+        if self.cal_element.load_state == "IDEAL":
+            return IDEAL_SHORT
+        if self.cal_element.load_state == "FILE":
+            self.cal_element.load_touchstone.gen_interpolation_s11()
+            dp = self.cal_element.load_touchstone.s_freq("11", freq)
+            return complex(dp.re, dp.im)
         logger.debug("Using load calibration set values.")
         cal_element = self.cal_element
         Zl = complex(cal_element.load_r, 0.0)
@@ -443,6 +456,7 @@ class Calibration:
         return cmath.exp(
             complex(0.0, -2.0 * math.pi * cal_element.through_length * freq)
         )
+    
 
     def gen_interpolation(self):
         (freq, e00, e11, delta_e, e10e01, e30, e22, e10e32) = zip(

--- a/src/NanoVNASaver/Touchstone.py
+++ b/src/NanoVNASaver/Touchstone.py
@@ -187,6 +187,34 @@ class Touchstone:
                     fill_value=(imag[0], imag[-1]),
                 ),
             }
+            
+    def gen_interpolation_s11(self):
+        freq = []
+        real = []
+        imag = []
+        for dp in self.s("11"):
+            freq.append(dp.freq)
+            real.append(dp.re)
+            imag.append(dp.im)
+
+        self._interp["11"] = {
+            "real": interp1d(
+                freq,
+                real,
+                kind="slinear",
+                bounds_error=False,
+                fill_value=(real[0], real[-1]),
+            ),
+            "imag": interp1d(
+                freq,
+                imag,
+                kind="slinear",
+                bounds_error=False,
+                fill_value=(imag[0], imag[-1]),
+            ),
+        }
+            
+
 
     def _parse_comments(self, fp) -> str:
         for line in fp:


### PR DESCRIPTION
Please check the type of change your PR introduces:

- [] Bugfix
- [*] Feature
- [] Code style update (formatting, renaming)
- [] Refactoring (no functional changes, no API changes)
- [] Build-related changes
- [] Documentation content changes
- [] Other (please describe):

## What is the current behavior?

Right now, you can either use ideal values or use coefficients (if your cal components are not ideal). However, if you use a VNA to measure your calibration kit, you just get a S1P file. While it is possible to derive the coefficients for the short and open, the load seems to be more complicated, especially at higher frequencies. 

## What is the new behavior?

You are now able to input S1P files for calibration.

## Does this introduce a breaking change?

- [] Yes
- [*] No


## Other information

I imported this S11 file for the open:
![image](https://github.com/user-attachments/assets/ed49ba7b-77cc-43e0-ac7f-a0c9a8c82066)

My results after calibration:
![image](https://github.com/user-attachments/assets/b83e2138-a53e-432a-af62-ea90eccb998f)

You can see that at 8GHz the phase is roughly 10 degrees.

For the load, I imported the blue trace here (S22):
![image](https://github.com/user-attachments/assets/830edd40-030f-4269-bbea-006df5f6225f)

Here are the results after calibration:
![image](https://github.com/user-attachments/assets/ee54cd78-f1a6-4c2f-adba-78954b2770b6)

(The VNA loses directivity above 6.3GHz which is why the return loss has spikes).

Here is what the change looks like:
![image](https://github.com/user-attachments/assets/7dea64fc-8bb1-4241-af57-af51e9c15555)
