### PR TITLE
chore: improve sweep and serial controls state

### DIFF
--- a/src/NanoVNASaver/Controls/SweepControl.py
+++ b/src/NanoVNASaver/Controls/SweepControl.py
@@ -114,6 +114,8 @@ class SweepControl(Control):
         self.btn_start.setShortcut(
             QtCore.Qt.Key.Key_Control + QtCore.Qt.Key.Key_W
         )
+        # Will be enabled when VNA is connected
+        self.btn_start.setEnabled(False)
         self.btn_stop = QtWidgets.QPushButton("Stop")
         self.btn_stop.setFixedHeight(20)
         self.btn_stop.clicked.connect(self.app.sweep_stop)
@@ -222,3 +224,6 @@ class SweepControl(Control):
             segments=self.get_segments(),
             points=self.app.vna.datapoints,
         )
+
+    def update_sweep_btn(self, enabled: bool) -> None:
+        self.btn_start.setEnabled(enabled)

--- a/src/NanoVNASaver/NanoVNASaver.py
+++ b/src/NanoVNASaver/NanoVNASaver.py
@@ -125,14 +125,15 @@ class NanoVNASaver(QWidget):
         self.marker_column.setContentsMargins(0, 0, 0, 0)
         self.marker_frame.setLayout(self.marker_column)
 
+        self.interface = Interface("serial", "None")
+        self.vna: type[VNA] = VNA(self.interface)
+        
         self.sweep_control = SweepControl(self)
         self.marker_control = MarkerControl(self)
         self.serial_control = SerialControl(self)
+        self.serial_control.connected.connect(self.sweep_control.update_sweep_btn)
 
         self.bands = BandsModel()
-
-        self.interface = Interface("serial", "None")
-        self.vna: type[VNA] = VNA(self.interface)
 
         self.dataLock = threading.Lock()
         self.data = Touchstone()


### PR DESCRIPTION
Disable some buttons when device is not connected:
- disable `Serial -> Manage` and` Sweep -> Start` button when device is not connected
- disable `Serial -> Connect` button when port was not selected
 
## Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [] Feature
- [] Code style update (formatting, renaming)
- [] Refactoring (no functional changes, no API changes)
- [] Build-related changes
- [] Documentation content changes
- [] Other (please describe):

## What is the current behavior?

There are two issues:
- it's possible to click connect button when no ports selected (e.g. no any physical devices connected)
- it's possible to open serial management OR start sweep when no VNA connected

These crash application. 

Issue Number: N/A

## What is the new behavior?

Disable connect button when no any physical devices existed.
Disable serial management dialog and sweep start button when no serial was connected. 

## Does this introduce a breaking change?

- [] Yes
- [x] No

## Other information
