### PR TITLE
Add LiteVNA 64 Support (Part 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ __pycache__/*
 .pydevproject
 .settings
 .idea
-.vscode
+!.vscode
 tags
 
 # Package files
@@ -58,3 +58,4 @@ NanoVNASaver.spec
 .python-version
 
 
+!.vscode/launch.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: NanoVNASaver",
+            "type": "python",
+            "request": "launch",
+            "module": "NanoVNASaver",
+            "justMyCode": true,
+            "args": ["-d", "-D NanoVNASaver-debug.log"],
+            "env": {"PYTHONPATH":"./src"}
+        },
+        {
+            "name": "Python: Current File",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal",
+            "justMyCode": true
+        }
+    ]
+}

--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ Current features
 
 
 * Reading data from a NanoVNA -- Compatible devices: NanoVNA, NanoVNA-H,
-  NanoVNA-H4, NanoVNA-F, AVNA via Teensy
+  NanoVNA-H4, NanoVNA-F, AVNA via Teensy, LiteVNA
 * Reading data from a TinySA
 * Splitting a frequency range into multiple segments to increase resolution
   (tried up to >10k points)

--- a/src/NanoVNASaver/Hardware/Hardware.py
+++ b/src/NanoVNASaver/Hardware/Hardware.py
@@ -37,6 +37,7 @@ from NanoVNASaver.Hardware.Serial import Interface, drain_serial
 from NanoVNASaver.Hardware.SV4401A import SV4401A
 from NanoVNASaver.Hardware.SV6301A import SV6301A
 from NanoVNASaver.Hardware.TinySA import TinySA, TinySA_Ultra
+from NanoVNASaver.Hardware.litevna_64 import LiteVNA64
 from NanoVNASaver.Hardware.VNA import VNA
 
 logger = logging.getLogger(__name__)
@@ -65,6 +66,7 @@ NAME2DEVICE = {
     "JNCRadio": JNCRadio_VNA_3G,
     "SV4401A": SV4401A,
     "SV6301A": SV6301A,
+    "LiteVNA64": LiteVNA64,
     "Unknown": NanoVNA,
 }
 
@@ -148,6 +150,8 @@ def get_comment(iface: Interface) -> str:
 
     if vna_version == "v2":
         return "S-A-A-2"
+    elif vna_version == "lite_vna_64":
+        return "LiteVNA64"
 
     logger.info("Finding firmware variant...")
     info = get_info(iface)
@@ -189,7 +193,7 @@ def detect_version(serial_port: serial.Serial) -> str:
         if data.startswith("\r\n?\r\nch> "):
             return "vh"
         if data.startswith("2"):
-            return "v2"
+            return "lite_vna_64" if LiteVNA64.is_lite_vna_64(serial_port) else "v2"
         logger.debug("Retry detection: %s", i + 1)
     logger.error("No VNA detected. Hardware responded to CR with: %s", data)
     return ""

--- a/src/NanoVNASaver/Hardware/litevna_64.py
+++ b/src/NanoVNASaver/Hardware/litevna_64.py
@@ -1,23 +1,20 @@
-from .NanoVNA_V2 import (
-    NanoVNA_V2,
-    _CMD_READ,
-    _ADDR_FW_MAJOR,
-    _ADDR_FW_MINOR,
-    _ADDR_DEVICE_VARIANT,
-    _ADDR_HARDWARE_REVISION,
-)
 import logging
-import platform
-from struct import pack, unpack_from
+from struct import pack
 from time import sleep
 
-from NanoVNASaver.Hardware.Serial import Interface
-from NanoVNASaver.Hardware.VNA import VNA
-from NanoVNASaver.Version import _Version as Version, Version as parse_version
 from serial import Serial
 
-if platform.system() != "Windows":
-    import tty
+from ..Version import Version as parse_version
+from ..Version import _Version as Version
+from .NanoVNA_V2 import (
+    _ADDR_DEVICE_VARIANT,
+    _ADDR_FW_MAJOR,
+    _ADDR_FW_MINOR,
+    _ADDR_HARDWARE_REVISION,
+    _CMD_READ,
+    NanoVNA_V2,
+)
+from .Serial import Interface
 
 logger = logging.getLogger(__name__)
 

--- a/src/NanoVNASaver/Hardware/litevna_64.py
+++ b/src/NanoVNASaver/Hardware/litevna_64.py
@@ -1,0 +1,83 @@
+from .NanoVNA_V2 import (
+    NanoVNA_V2,
+    _CMD_READ,
+    _ADDR_FW_MAJOR,
+    _ADDR_FW_MINOR,
+    _ADDR_DEVICE_VARIANT,
+    _ADDR_HARDWARE_REVISION,
+)
+import logging
+import platform
+from struct import pack, unpack_from
+from time import sleep
+
+from NanoVNASaver.Hardware.Serial import Interface
+from NanoVNASaver.Hardware.VNA import VNA
+from NanoVNASaver.Version import _Version as Version, Version as parse_version
+from serial import Serial
+
+if platform.system() != "Windows":
+    import tty
+
+logger = logging.getLogger(__name__)
+
+EXPECTED_HW_VERSION = Version(2, 2, 0, "")
+EXPECTED_FW_VERSION = Version(2, 2, 0, "")
+
+
+class LiteVNA64(NanoVNA_V2):
+    name = "LiteVNA-64"
+    valid_datapoints = (101, 11, 51, 201, 301, 501, 1023, 2047, 4095)
+    screenwidth = 480
+    screenheight = 320
+    sweep_points_max = 65535
+
+    def __init__(self, iface: Interface):
+        super().__init__(iface)
+
+    @staticmethod
+    def _read_major_minor_version(
+        cmd_major_version: int, cmd_minor_version: int, serial: Serial
+    ) -> Version:
+        cmd = pack(
+            "<BBBB", _CMD_READ, cmd_major_version, _CMD_READ, cmd_minor_version
+        )
+
+        serial.write(cmd)
+        # sleep(WRITE_SLEEP)
+        sleep(2.0)  # could fix bug #585 but shoud be done
+        # in a more predictive way
+        resp = serial.read(2)
+
+        if len(resp) != 2:  # noqa: PLR2004
+            logger.error("Timeout reading version registers. Got: %s", resp)
+            raise IOError("Timeout reading version registers")
+        return parse_version(f"{resp[0]}.{resp[1]}")
+
+    @staticmethod
+    def read_fw_version(serial: Serial) -> Version:
+        result = LiteVNA64._read_major_minor_version(
+            _ADDR_FW_MAJOR, _ADDR_FW_MINOR, serial
+        )
+        logger.debug("Firmware version: %s", result)
+        return result
+
+    @staticmethod
+    def read_hw_revision(serial: Serial) -> Version:
+        result = LiteVNA64._read_major_minor_version(
+            _ADDR_DEVICE_VARIANT, _ADDR_HARDWARE_REVISION, serial
+        )
+        logger.debug(
+            "Hardware version ({device_variant}.{hardware_revision}): %s",
+            result,
+        )
+        return result
+
+    @staticmethod
+    def is_lite_vna_64(serial: Serial) -> bool:
+        hw_version = LiteVNA64.read_hw_revision(serial)
+        fw_version = LiteVNA64.read_fw_version(serial)
+        return (
+            hw_version == EXPECTED_HW_VERSION
+            and fw_version == EXPECTED_FW_VERSION
+        )


### PR DESCRIPTION
Initial version for LiteVNA support. Based on https://github.com/NanoVNA-Saver/nanovna-saver/issues/534 discussion.

## Pull Request type

Please check the type of change your PR introduces:

- [] Bugfix
- [x] Feature
- [] Code style update (formatting, renaming)
- [] Refactoring (no functional changes, no API changes)
- [] Build-related changes
- [] Documentation content changes
- [] Other (please describe):

## What is the current behavior?

LiteVNA64 is detected as SAA2 device. This works somehow however it isn't possible to unitize all hardware functionality (e.g. enable more than 1023 points)

Issue Number: 534

## What is the new behavior?

- LiteVNA device is detected as LIteVNA64 device
- It's possible to specify up to 65K points

## Does this introduce a breaking change?

- [] Yes
- [x] No

## Other information

The rest of LiteVNA features will be in separated PRs.
