### PR TITLE
Add support for tinySA Ultra+ ZS-407, ZS-406, ZS-405 and tinySA and fix crashing due to operations on Integer

### DIFF
--- a/src/NanoVNASaver/Hardware/Hardware.py
+++ b/src/NanoVNASaver/Hardware/Hardware.py
@@ -182,7 +182,6 @@ def detect_version(serial_port: serial.Serial) -> str:
         sleep(0.05)
 
         data = serial_port.read(128).decode("ascii")
-
         if data.startswith("ch> "):
             return "v1"
         # -H versions

--- a/src/NanoVNASaver/Hardware/Hardware.py
+++ b/src/NanoVNASaver/Hardware/Hardware.py
@@ -140,7 +140,6 @@ def get_portinfos() -> list[str]:
 
 def get_VNA(iface: Interface) -> VNA:
     # serial_port.timeout = TIMEOUT
-    # debug1
     return NAME2DEVICE[iface.comment](iface)
 
 def get_comment(iface: Interface) -> str:

--- a/src/NanoVNASaver/Hardware/Hardware.py
+++ b/src/NanoVNASaver/Hardware/Hardware.py
@@ -30,6 +30,7 @@ from NanoVNASaver.Hardware.JNCRadio_VNA_3G import JNCRadio_VNA_3G
 from NanoVNASaver.Hardware.NanoVNA import NanoVNA
 from NanoVNASaver.Hardware.NanoVNA_F import NanoVNA_F
 from NanoVNASaver.Hardware.NanoVNA_F_V2 import NanoVNA_F_V2
+from NanoVNASaver.Hardware.NanoVNA_F_V3 import NanoVNA_F_V3
 from NanoVNASaver.Hardware.NanoVNA_H import NanoVNA_H
 from NanoVNASaver.Hardware.NanoVNA_H4 import NanoVNA_H4
 from NanoVNASaver.Hardware.NanoVNA_V2 import NanoVNA_V2
@@ -58,6 +59,7 @@ NAME2DEVICE = {
     "H4": NanoVNA_H4,
     "H": NanoVNA_H,
     "F_V2": NanoVNA_F_V2,
+    "F_V3": NanoVNA_F_V3,
     "F": NanoVNA_F,
     "NanoVNA": NanoVNA,
     "tinySA": TinySA,
@@ -138,14 +140,13 @@ def get_portinfos() -> list[str]:
 
 def get_VNA(iface: Interface) -> VNA:
     # serial_port.timeout = TIMEOUT
+    # debug1
     return NAME2DEVICE[iface.comment](iface)
-
 
 def get_comment(iface: Interface) -> str:
     logger.info("Finding correct VNA type...")
     with iface.lock:
         vna_version = detect_version(iface)
-
     if vna_version == "v2":
         return "S-A-A-2"
 
@@ -156,6 +157,7 @@ def get_comment(iface: Interface) -> str:
         ("NanoVNA-H 4", "H4"),
         ("NanoVNA-H", "H"),
         ("NanoVNA-F_V2", "F_V2"),
+        ("NanoVNA-F_V3", "F_V3"),
         ("NanoVNA-F", "F"),
         ("NanoVNA", "NanoVNA"),
         ("tinySA4", "tinySA_Ultra"),
@@ -181,6 +183,7 @@ def detect_version(serial_port: serial.Serial) -> str:
         sleep(0.05)
 
         data = serial_port.read(128).decode("ascii")
+
         if data.startswith("ch> "):
             return "v1"
         # -H versions

--- a/src/NanoVNASaver/Hardware/NanoVNA_F_V3.py
+++ b/src/NanoVNASaver/Hardware/NanoVNA_F_V3.py
@@ -31,9 +31,9 @@ class NanoVNA_F_V3(NanoVNA):
     name = "NanoVNA-F_V3"
     screenwidth = 800
     screenheight = 480
-    valid_datapoints = (101, 11, 51, 201, 301, 501, 801)
+    valid_datapoints = (101, 11, 51, 201, 301, 401, 501, 601, 701, 801, 1023, 2047, 4095)
     sweep_points_min = 11
-    sweep_points_max = 801
+    sweep_points_max = 65535
 
     def __init__(self, iface: Interface):
         super().__init__(iface)

--- a/src/NanoVNASaver/Hardware/NanoVNA_F_V3.py
+++ b/src/NanoVNASaver/Hardware/NanoVNA_F_V3.py
@@ -31,9 +31,9 @@ class NanoVNA_F_V3(NanoVNA):
     name = "NanoVNA-F_V3"
     screenwidth = 800
     screenheight = 480
-    valid_datapoints = (101, 11, 51, 201, 301, 401, 501, 601, 701, 801, 1023, 2047, 4095)
+    valid_datapoints = (101, 11, 51, 201, 301, 401, 501, 601, 701, 801)
     sweep_points_min = 11
-    sweep_points_max = 65535
+    sweep_points_max = 801
 
     def __init__(self, iface: Interface):
         super().__init__(iface)
@@ -56,3 +56,13 @@ class NanoVNA_F_V3(NanoVNA):
         except serial.SerialException as exc:
             logger.exception("Exception while capturing screenshot: %s", exc)
         return QPixmap()
+    
+    def read_features(self):
+        super().read_features()
+        result = " ".join(self.exec_command("help")).split()
+        if "sn:" or "SN:" in result:
+            self.features.add("SN")
+            self.SN = self.getSerialNumber()
+            
+    def getSerialNumber(self) -> str:
+        return " ".join(list(self.exec_command("SN"))) if 'SN:' in " ".join(self.exec_command("help")).split() else " ".join(list(self.exec_command("sn")))

--- a/src/NanoVNASaver/Hardware/NanoVNA_F_V3.py
+++ b/src/NanoVNASaver/Hardware/NanoVNA_F_V3.py
@@ -1,0 +1,58 @@
+#  NanoVNASaver
+#
+#  A python program to view and export Touchstone data from a NanoVNA
+#  Copyright (C) 2019, 2020  Rune B. Broberg
+#  Copyright (C) 2020,2021 NanoVNA-Saver Authors
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import logging
+
+import serial
+from PyQt6.QtGui import QImage, QPixmap
+
+from NanoVNASaver.Hardware.NanoVNA import NanoVNA
+from NanoVNASaver.Hardware.Serial import Interface
+
+logger = logging.getLogger(__name__)
+
+
+class NanoVNA_F_V3(NanoVNA):
+    name = "NanoVNA-F_V3"
+    screenwidth = 800
+    screenheight = 480
+    valid_datapoints = (101, 11, 51, 201, 301, 501, 801)
+    sweep_points_min = 11
+    sweep_points_max = 801
+
+    def __init__(self, iface: Interface):
+        super().__init__(iface)
+        self.sweep_max_freq_Hz = 6.3e9
+
+    def getScreenshot(self) -> QPixmap:
+        logger.debug("Capturing screenshot...")
+        if not self.connected():
+            return QPixmap()
+        try:
+            rgba_array = self._capture_data()
+            image = QImage(
+                rgba_array,
+                self.screenwidth,
+                self.screenheight,
+                QImage.Format.Format_RGB16,
+            )
+            logger.debug("Captured screenshot")
+            return QPixmap(image)
+        except serial.SerialException as exc:
+            logger.exception("Exception while capturing screenshot: %s", exc)
+        return QPixmap()

--- a/src/NanoVNASaver/Hardware/TinySA.py
+++ b/src/NanoVNASaver/Hardware/TinySA.py
@@ -156,6 +156,7 @@ class TinySA_Ultra(TinySA):  # noqa: N801
             self.name = "tinySA Ultra ZS-405"
             self.sweep_max_freq_Hz = 5.3e9
         else:
+            # version 0.3.x is for tinySA
             self.name = "tinySA"
             self.sweep_max_freq_Hz = 0.96e9
             

--- a/src/NanoVNASaver/Hardware/VNA.py
+++ b/src/NanoVNASaver/Hardware/VNA.py
@@ -56,7 +56,6 @@ class VNA:
     valid_datapoints = (101, 51, 11)
     wait = 0.05
     SN = "NOT SUPPORTED"
-
     sweep_points_max = 101
     sweep_points_min = 11
 

--- a/src/NanoVNASaver/Hardware/VNA.py
+++ b/src/NanoVNASaver/Hardware/VNA.py
@@ -126,11 +126,9 @@ class VNA:
         logger.debug("result:\n%s", result)
         if "capture" in result:
             self.features.add("Screenshots")
-
         if "sn:" in result:
             self.features.add("SN")
             self.SN = self.getSerialNumber()
-
         if "bandwidth" in result:
             self.features.add("Bandwidth")
             result = " ".join(list(self.exec_command("bandwidth")))

--- a/src/NanoVNASaver/Hardware/VNA.py
+++ b/src/NanoVNASaver/Hardware/VNA.py
@@ -56,6 +56,7 @@ class VNA:
     valid_datapoints = (101, 51, 11)
     wait = 0.05
     SN = "NOT SUPPORTED"
+
     sweep_points_max = 101
     sweep_points_min = 11
 
@@ -126,9 +127,13 @@ class VNA:
         logger.debug("result:\n%s", result)
         if "capture" in result:
             self.features.add("Screenshots")
-        if "sn:" in result:
+
+        #mod#
+        if "sn:" or "SN:" in result:
             self.features.add("SN")
             self.SN = self.getSerialNumber()
+        #end-mod#
+
         if "bandwidth" in result:
             self.features.add("Bandwidth")
             result = " ".join(list(self.exec_command("bandwidth")))
@@ -220,4 +225,5 @@ class VNA:
         raise NotImplementedError()
 
     def getSerialNumber(self) -> str:
-        return " ".join(list(self.exec_command("sn")))
+        # return " ".join(list(self.exec_command("sn")))
+        return " ".join(list(self.exec_command("SN")))

--- a/src/NanoVNASaver/Hardware/VNA.py
+++ b/src/NanoVNASaver/Hardware/VNA.py
@@ -225,5 +225,4 @@ class VNA:
         raise NotImplementedError()
 
     def getSerialNumber(self) -> str:
-        # return " ".join(list(self.exec_command("sn")))
-        return " ".join(list(self.exec_command("SN")))
+        return " ".join(list(self.exec_command("SN"))) if 'SN:' in " ".join(self.exec_command("help")).split() else " ".join(list(self.exec_command("sn")))

--- a/src/NanoVNASaver/Hardware/VNA.py
+++ b/src/NanoVNASaver/Hardware/VNA.py
@@ -128,11 +128,9 @@ class VNA:
         if "capture" in result:
             self.features.add("Screenshots")
 
-        #mod#
         if "sn:" or "SN:" in result:
             self.features.add("SN")
             self.SN = self.getSerialNumber()
-        #end-mod#
 
         if "bandwidth" in result:
             self.features.add("Bandwidth")

--- a/src/NanoVNASaver/Hardware/VNA.py
+++ b/src/NanoVNASaver/Hardware/VNA.py
@@ -127,7 +127,7 @@ class VNA:
         if "capture" in result:
             self.features.add("Screenshots")
 
-        if "sn:" or "SN:" in result:
+        if "sn:" in result:
             self.features.add("SN")
             self.SN = self.getSerialNumber()
 
@@ -222,4 +222,4 @@ class VNA:
         raise NotImplementedError()
 
     def getSerialNumber(self) -> str:
-        return " ".join(list(self.exec_command("SN"))) if 'SN:' in " ".join(self.exec_command("help")).split() else " ".join(list(self.exec_command("sn")))
+        return " ".join(list(self.exec_command("sn")))


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

- Add support for Spectrum Analyzer tinySA Ultra+ ZS-407, ZS-406, ZS-405 and tinySA and fix crashing due to operations on Integer
- Add correct model type and firmware version number shown in nanovna-saver app
- Add a property called `hardware_revision` in **class** `TinySA_Ultra` for future need which would be displayed in the __**Device settings**__ -> **Status**

This is an onward pull-request after my another pull-request for adding support for NanoVNA-F V3 from here: <https://github.com/NanoVNA-Saver/nanovna-saver/pull/751>
## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Crashing due to bad operations on Integer when testing with a tinySA Ultra+ ZS-407

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Display correct model type, firmware version of all tinySA (Ultra or Ultra+)
- Fix crashing

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

![Xnip2025-01-16_21-33-40](https://github.com/user-attachments/assets/e775f238-c6c5-4b52-9ea9-a574278f5809)

**Sometimes it's very useful to capture screenshot of tinySA (Ultra or Ultra+) with nanovna-saver app on macOS because the outdated tinysa-app delivered by someone only work on Windows**
