### PR TITLE
fix: settings restoring (Part 2)

### DIFF
--- a/src/NanoVNASaver/Defaults.py
+++ b/src/NanoVNASaver/Defaults.py
@@ -154,7 +154,7 @@ class AppSettings(QSettings):
         self._app_config = AppConfig()
 
     def get_app_config(self) -> AppConfig:
-        return _app_config
+        return self._app_config
 
     def _store_dataclass(self, name: str, data: object) -> None:
         assert is_dataclass(data)
@@ -204,15 +204,15 @@ class AppSettings(QSettings):
             setattr(result, field_it.name, value)
         logger.debug("restored\n(\n%s\n)", result)
         self._app_config = result
-        return get_app_config()
+        return self.get_app_config()
 
 
     def store_config(self) -> None:
         logger.info("Saving settings to: %s", self.fileName())
 
-        logger.debug("storing\n(\n%s\n)", _app_config)
-        for field_it in fields(_app_config):
-            data_class = getattr(_app_config, field_it.name)
+        logger.debug("storing\n(\n%s\n)", self._app_config)
+        for field_it in fields(self._app_config):
+            data_class = getattr(self._app_config, field_it.name)
             assert is_dataclass(data_class)
             self._store_dataclass(field_it.name.upper(), data_class)
 
@@ -243,8 +243,6 @@ class AppSettings(QSettings):
 
 
 APP_SETTINGS = AppSettings()
-
-_app_config = AppConfig()
 
 def get_app_config() -> AppConfig:
     return APP_SETTINGS.get_app_config()

--- a/src/NanoVNASaver/NanoVNASaver.py
+++ b/src/NanoVNASaver/NanoVNASaver.py
@@ -54,7 +54,7 @@ from .Charts.Chart import Chart
 from .Controls.MarkerControl import MarkerControl
 from .Controls.SerialControl import SerialControl
 from .Controls.SweepControl import SweepControl
-from .Defaults import AppSettings, get_app_config
+from .Defaults import APP_SETTINGS, get_app_config
 from .Formatting import format_frequency, format_gain, format_vswr
 from .Hardware.Hardware import Interface
 from .Hardware.VNA import VNA
@@ -93,7 +93,8 @@ class NanoVNASaver(QWidget):
         self.communicate = Communicate()
         self.s21att = 0.0
         self.setWindowIcon(get_window_icon())
-        self.settings = AppSettings()
+        # TODO APP_SETTINGS should be used instead app.setting\
+        self.settings = APP_SETTINGS
         app_config = self.settings.restore_config()
         self.threadpool = QtCore.QThreadPool()
         self.sweep = Sweep()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -88,8 +88,8 @@ class TestCases(unittest.TestCase):
     def test_store(self):
         tc_1 = self.settings_2.get_app_config()
         tc_1.gui.dark_mode = not tc_1.gui.dark_mode
-
         self.settings_2.store_config()
+
         tc_2 = self.settings_2.restore_config()
         print(f"\n{tc_1}\n{tc_2}\n")
         self.assertEqual(tc_1, tc_2)


### PR DESCRIPTION
Fix application settings restoring
It's a followup for https://github.com/NanoVNA-Saver/nanovna-saver/pull/778, MyPy absence is bit frustrating

It fixes https://github.com/NanoVNA-Saver/nanovna-saver/issues/777 and was mentioned in https://github.com/NanoVNA-Saver/nanovna-saver/issues/768

## Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [] Feature
- [] Code style update (formatting, renaming)
- [] Refactoring (no functional changes, no API changes)
- [] Build-related changes
- [] Documentation content changes
- [] Other (please describe):

## What is the current behavior?

- some of settings (e.g. font size) are not restored between run sessions
- sweep configuration is not saved between run sessions
- app crashes right before exit

Issue Number: [777](https://github.com/NanoVNA-Saver/nanovna-saver/issues/777)

## What is the new behavior?

settings are saved on exit and restored on app start

## Does this introduce a breaking change?

- [] Yes
- [x] No

## Other information
