### PR TITLE
fix: sweep worker stopping

### DIFF
--- a/src/NanoVNASaver/Controls/SweepControl.py
+++ b/src/NanoVNASaver/Controls/SweepControl.py
@@ -120,7 +120,7 @@ class SweepControl(Control):
         self.btn_start.setEnabled(False)
         self.btn_stop = QtWidgets.QPushButton("Stop")
         self.btn_stop.setFixedHeight(20)
-        self.btn_stop.clicked.connect(self.app.sweep_stop)
+        self.btn_stop.clicked.connect(self.app.worker.quit)
         self.btn_stop.setShortcut(QtCore.Qt.Key.Key_Escape)
         self.btn_stop.setDisabled(True)
         btn_layout = QtWidgets.QHBoxLayout()

--- a/src/NanoVNASaver/Settings/Sweep.py
+++ b/src/NanoVNASaver/Settings/Sweep.py
@@ -113,7 +113,7 @@ class Sweep:
 
     # Properties are immutable, this does not circumvent the accessors.
     @property
-    def properties(self) -> "Properties":
+    def properties(self) -> Properties:
         return self._properties
 
     @property


### PR DESCRIPTION
fix for https://github.com/NanoVNA-Saver/nanovna-saver/issues/773 bug

## Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [] Feature
- [] Code style update (formatting, renaming)
- [] Refactoring (no functional changes, no API changes)
- [] Build-related changes
- [] Documentation content changes
- [] Other (please describe):

## What is the current behavior?

- unable to stop continues sweeping
- unable to close app gracefully when sweeping in progress

Issue Number: https://github.com/NanoVNA-Saver/nanovna-saver/issues/773

## What is the new behavior?

- The "stop" button stops the next sweep cycle
- application try to stop sweep cycle before exit (waits 10 sec before hard interruption) 

## Does this introduce a breaking change?

- [] Yes
- [x] No

## Other information

`SweepState` usages should be reviewed, looks like QtThread.isRunning() may be used instead.
