### PR TITLE
fix: widget styles for about window

### DIFF
--- a/src/NanoVNASaver/Windows/ui/about.py
+++ b/src/NanoVNASaver/Windows/ui/about.py
@@ -103,7 +103,7 @@ class Ui_DialogAbout(object):
 
         self._frm_updates_status = QFrame(DialogAbout)
         self._frm_updates_status.setObjectName(u"_frm_updates_status")
-        self._frm_updates_status.setFrameShape(QFrame.Shape.StyledPanel)
+        self._frm_updates_status.setFrameShape(QFrame.Shape.NoFrame)
         self._frm_updates_status.setFrameShadow(QFrame.Shadow.Raised)
         self.horizontalLayout_2 = QHBoxLayout(self._frm_updates_status)
         self.horizontalLayout_2.setSpacing(0)
@@ -149,7 +149,7 @@ class Ui_DialogAbout(object):
         self.verticalLayout_2.setContentsMargins(0, 0, 0, 0)
         self._frm_runtime_info_1 = QFrame(self._frm_runtime_info)
         self._frm_runtime_info_1.setObjectName(u"_frm_runtime_info_1")
-        self._frm_runtime_info_1.setFrameShape(QFrame.Shape.StyledPanel)
+        self._frm_runtime_info_1.setFrameShape(QFrame.Shape.NoFrame)
         self._frm_runtime_info_1.setFrameShadow(QFrame.Shadow.Raised)
         self.horizontalLayout = QHBoxLayout(self._frm_runtime_info_1)
         self.horizontalLayout.setSpacing(0)

--- a/src/NanoVNASaver/Windows/ui/about.ui
+++ b/src/NanoVNASaver/Windows/ui/about.ui
@@ -159,7 +159,7 @@
    <item>
     <widget class="QFrame" name="_frm_updates_status">
      <property name="frameShape">
-      <enum>QFrame::Shape::StyledPanel</enum>
+      <enum>QFrame::Shape::NoFrame</enum>
      </property>
      <property name="frameShadow">
       <enum>QFrame::Shadow::Raised</enum>
@@ -261,7 +261,7 @@
       <item>
        <widget class="QFrame" name="_frm_runtime_info_1">
         <property name="frameShape">
-         <enum>QFrame::Shape::StyledPanel</enum>
+         <enum>QFrame::Shape::NoFrame</enum>
         </property>
         <property name="frameShadow">
          <enum>QFrame::Shadow::Raised</enum>


### PR DESCRIPTION
e.g. see screenshot from https://github.com/NanoVNA-Saver/nanovna-saver/issues/773#issuecomment-2629026606

## Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [] Feature
- [] Code style update (formatting, renaming)
- [] Refactoring (no functional changes, no API changes)
- [] Build-related changes
- [] Documentation content changes
- [] Other (please describe):

## What is the current behavior?
Some areas in an `About` window was different background color.

Issue Number: N/A

## What is the new behavior?
Whole window area has the same styling

## Does this introduce a breaking change?

- [] Yes
- [x] No

## Other information

