### PR TITLE
Zooming and panning in TDR window and choosing fft window type

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -241,3 +241,4 @@ below:
 .. image:: https://www.paypalobjects.com/en_US/i/btn/btn_donate_LG.gif
    :target: https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=T8KTGVDQF5K6E&item_name=NanoVNASaver+Development&currency_code=EUR&source=url
    :alt: Paypal
+

--- a/src/NanoVNASaver/Charts/Chart.py
+++ b/src/NanoVNASaver/Charts/Chart.py
@@ -258,8 +258,10 @@ class Chart(QtWidgets.QWidget):
 
     def wheelEvent(self, a0: QtGui.QWheelEvent) -> None:
         delta = a0.angleDelta().y()
+        logger.debug(f"wheelEvent {delta}, {self.data}, {self.reference}")
         if not delta or (not self.data and not self.reference):
             a0.ignore()
+            logger.debug("nothing to do, returning")
             return
         modifiers = a0.modifiers()
 

--- a/src/NanoVNASaver/Charts/Chart.py
+++ b/src/NanoVNASaver/Charts/Chart.py
@@ -358,3 +358,15 @@ class Chart(QtWidgets.QWidget):
         pal.setColor(QtGui.QPalette.ColorRole.Window, Chart.color.background)
         self.setPalette(pal)
         super().update()
+
+    def drawDragbog(self, qp: QtGui.QPainter):
+        dashed_pen = QtGui.QPen(Chart.color.foreground, 1, Qt.PenStyle.DashLine)
+        qp.setPen(dashed_pen)
+        top_left = QtCore.QPoint(
+            self.dragbox.pos_start[0], self.dragbox.pos_start[1]
+        )
+        bottom_right = QtCore.QPoint(self.dragbox.pos[0], self.dragbox.pos[1])
+        rect = QtCore.QRect(top_left, bottom_right)
+        qp.drawRect(rect)
+
+

--- a/src/NanoVNASaver/Charts/Frequency.py
+++ b/src/NanoVNASaver/Charts/Frequency.py
@@ -513,16 +513,6 @@ class FrequencyChart(Chart):
                 "Data outside frequency span",
             )
 
-    def drawDragbog(self, qp: QtGui.QPainter):
-        dashed_pen = QtGui.QPen(Chart.color.foreground, 1, Qt.PenStyle.DashLine)
-        qp.setPen(dashed_pen)
-        top_left = QtCore.QPoint(
-            self.dragbox.pos_start[0], self.dragbox.pos_start[1]
-        )
-        bottom_right = QtCore.QPoint(self.dragbox.pos[0], self.dragbox.pos[1])
-        rect = QtCore.QRect(top_left, bottom_right)
-        qp.drawRect(rect)
-
     def drawChart(self, qp: QtGui.QPainter):
         qp.setPen(QtGui.QPen(Chart.color.text))
         headline = self.name

--- a/src/NanoVNASaver/Charts/TDR.py
+++ b/src/NanoVNASaver/Charts/TDR.py
@@ -301,13 +301,11 @@ class TDRChart(Chart):
         return new_chart
 
     def wheelEvent(self, a0: QWheelEvent) -> None:
-        logger.debug(f"wheelEvent {a0.angleDelta().y()}")
         a0.accept()
         self.data = [0]  # A bit of cheating otherwise the super().wheelEvent() exits without doing anything.
         super().wheelEvent(a0)
 
     def mouseMoveEvent(self, a0: QMouseEvent) -> None:
-        print(f"mouseMoveEvent: {Qt.MouseButton}")
         if not hasattr(self.tdrWindow, "td"):
             return
         if a0.buttons() == Qt.MouseButton.RightButton:
@@ -394,7 +392,6 @@ class TDRChart(Chart):
     def _draw_y_ticks(
         self, height, width, min_impedance, max_impedance, qp: QPainter
     ) -> None:
-        # qp = QPainter(self)
         y_step = (max_impedance - min_impedance) / height
         y_ticks = math.floor(height / 60)
         y_tick_step = height / y_ticks
@@ -413,7 +410,6 @@ class TDRChart(Chart):
         )
 
     def _draw_max_point(self, height, x_step, y_step, min_index, qp: QPainter) -> None:
-        # qp = QPainter(self)
         id_max = np.argmax(self.tdrWindow.td)
 
         max_point = QPoint(
@@ -432,7 +428,6 @@ class TDRChart(Chart):
         )
 
     def _draw_marker(self, height, x_step, y_step, min_index, qp: QPainter):
-        # qp = QPainter(self)
         marker_point = QPoint(
             self.leftMargin + int((self.marker_location - min_index) / x_step),
             (self.topMargin + height)
@@ -478,12 +473,9 @@ class TDRChart(Chart):
             min_impedance = self.min_y_lim
             max_impedance = self.max_y_lim
 
-        y_step = max(self.tdrWindow.td) * 1.1 / height or 1.0e-30
-
         self._draw_ticks(height, width, x_step, min_index, qp)
         self._draw_y_ticks(height, width, min_impedance, max_impedance, qp)
 
-        # qp = QPainter(self)
         pen = QPen(Chart.color.sweep)
         pen.setWidth(self.dim.line if self.flag.draw_lines else self.dim.point)
         qp.setPen(pen)
@@ -621,11 +613,8 @@ class TDRChart(Chart):
             "Zoom to (x,y) by (x,y): (%d, %d) by (%d, %d)", x1, y1, x2, y2
         )
 
-        logger.debug(f"min_display_length: {self.min_display_length} - {self.max_display_length}")
         val1 = self.valueAtPosition(y1)
         val2 = self.valueAtPosition(y2)
-
-        logger.debug(f"new val1={val1}, new val2={val2}")
 
         if val1 != val2:
             self.min_y_lim = round(min(val1, val2), 3)
@@ -643,8 +632,6 @@ class TDRChart(Chart):
 
         len1 = max(0, self.lengthAtPosition(x_min, limit=False))
         len2 = max(0, self.lengthAtPosition(x_max, limit=False))
-
-        logger.debug(f"new len1={len1}, new len2={len2}")
 
         if len1 >= 0 and len2 >= 0 and len1 != len2:
             self.min_display_length = min(len1, len2)

--- a/src/NanoVNASaver/Windows/SweepSettings.py
+++ b/src/NanoVNASaver/Windows/SweepSettings.py
@@ -261,7 +261,7 @@ class SweepSettingsWindow(QtWidgets.QWidget):
             format_frequency_sweep(stop)
         )
         self.app.sweep_control.inputs["Stop"].textEdited.emit(
-            self.app.sweep_control.input_end.text()
+            self.app.sweep_control.inputs["Stop"].text()
         )
 
     def update_attenuator(self, value: "QtWidgets.QLineEdit"):

--- a/src/NanoVNASaver/Windows/TDR.py
+++ b/src/NanoVNASaver/Windows/TDR.py
@@ -23,11 +23,14 @@ from typing import TYPE_CHECKING
 import numpy as np
 import numpy.typing as npt
 from PySide6 import QtCore, QtGui, QtWidgets
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QShortcut
 from scipy.constants import speed_of_light  # type: ignore
 from scipy.signal import convolve  # type: ignore
 
 from .Defaults import make_scrollable
 from .ui import get_window_icon
+
 
 if TYPE_CHECKING:
     from ..NanoVNASaver.NanoVNASaver import NanoVNASaver as vna_app
@@ -115,7 +118,7 @@ class TDRWindow(QtWidgets.QWidget):
         self.setWindowTitle("TDR")
         self.setWindowIcon(get_window_icon())
 
-        QtGui.QShortcut(QtCore.Qt.Key.Key_Escape, self, self.hide)
+        QShortcut(Qt.Key.Key_Escape, self, self.hide)
 
         layout = QtWidgets.QFormLayout()
         make_scrollable(self, layout)
@@ -156,7 +159,7 @@ class TDRWindow(QtWidgets.QWidget):
 
         self.window_dropdown = QtWidgets.QComboBox()
         for method_name, method_call, method_correction, method_arg in WINDOWING_FUNCTION:
-            self.window_dropdown.addItem(method_name, {'call': method_call, 'arg': method_arg, 'corr': method_correction})
+            self.window_dropdown.addItem(method_name, {'function': method_call, 'arg': method_arg, 'corr': method_correction})
         self.window_dropdown.currentIndexChanged.connect(self.updateTDR)
         self.window_dropdown.setCurrentIndex(0)
         layout.addRow("Window", self.window_dropdown)
@@ -211,14 +214,9 @@ class TDRWindow(QtWidgets.QWidget):
             )
 
         if TDR_window['arg'] is None:
-            self.windowed_s11 = TDR_window['call'](len(s11)) * s11
+            self.windowed_s11 = TDR_window['function'](len(s11)) * s11
         else:
-            self.windowed_s11 = TDR_window['call'](len(s11), TDR_window['arg']) * s11
-
-        # self.windowed_s11 = np.blackman(len(s11)) * s11
-        # self.windowed_s11 = np.kaiser(len(s11), 6) * s11
-
-        # correction_kaiser = 20*log10(256/sum(kaiser(101,6)))
+            self.windowed_s11 = TDR_window['function'](len(s11), TDR_window['arg']) * s11
 
         if "lowpass" in TDR_format:
             td = self._tdr_lowpass(TDR_format, s11, TDR_window)

--- a/src/NanoVNASaver/Windows/TDR.py
+++ b/src/NanoVNASaver/Windows/TDR.py
@@ -72,7 +72,7 @@ CABLE_PARAMETERS = (
     ("Davis Bury-FLEX (0.82)", 0.82),
 )
 
-MIN_DATA_LENGHT = 2
+MIN_DATA_LENGTH = 2
 
 # TODO: Let the user select whether to use high or low resolution TDR?
 FFT_POINTS = 2**14
@@ -149,12 +149,12 @@ class TDRWindow(QtWidgets.QWidget):
                 str(self.tdr_velocity_dropdown.currentData())
             )
 
-        if len(self.app.data.s11) < MIN_DATA_LENGHT:
-            return
-
         try:
             v = float(self.tdr_velocity_input.text())
         except ValueError:
+            return
+
+        if len(self.app.data.s11) < MIN_DATA_LENGTH:
             return
 
         step_size = self.app.data.s11[1].freq - self.app.data.s11[0].freq

--- a/src/NanoVNASaver/Windows/TDR.py
+++ b/src/NanoVNASaver/Windows/TDR.py
@@ -140,11 +140,7 @@ class TDRWindow(QtWidgets.QWidget):
         self.updateTDR()
 
     def updateTDR(self):
-        if len(self.app.data.s11) < MIN_DATA_LENGHT:
-            return
-
         TDR_format = self.format_dropdown.currentText()
-
         if self.tdr_velocity_dropdown.currentData() == -1:
             self.tdr_velocity_input.setDisabled(False)
         else:
@@ -152,6 +148,9 @@ class TDRWindow(QtWidgets.QWidget):
             self.tdr_velocity_input.setText(
                 str(self.tdr_velocity_dropdown.currentData())
             )
+
+        if len(self.app.data.s11) < MIN_DATA_LENGHT:
+            return
 
         try:
             v = float(self.tdr_velocity_input.text())

--- a/src/NanoVNASaver/Windows/TDR.py
+++ b/src/NanoVNASaver/Windows/TDR.py
@@ -124,7 +124,7 @@ class TDRWindow(QtWidgets.QWidget):
         make_scrollable(self, layout)
 
         dropdown_layout = QtWidgets.QHBoxLayout()
-        dropdown_layout.addWidget(QtWidgets.QLabel("Velocity factor"))
+        dropdown_layout.addWidget(QtWidgets.QLabel("Velocity factor"), 0)
 
         self.tdr_velocity_dropdown = QtWidgets.QComboBox()
         for cable_name, velocity in CABLE_PARAMETERS:
@@ -136,17 +136,19 @@ class TDRWindow(QtWidgets.QWidget):
         self.tdr_velocity_dropdown.setCurrentIndex(1)  # Default to PE (0.66)
         self.tdr_velocity_dropdown.currentIndexChanged.connect(self.updateTDR)
 
-        dropdown_layout.addWidget(self.tdr_velocity_dropdown)
+        dropdown_layout.addWidget(self.tdr_velocity_dropdown, 1)
 
         self.tdr_velocity_input = QtWidgets.QLineEdit()
         self.tdr_velocity_input.setDisabled(True)
         self.tdr_velocity_input.setText("0.66")
         self.tdr_velocity_input.textChanged.connect(self.app.dataUpdated)
         self.tdr_velocity_input.setValidator(QtGui.QDoubleValidator(0.01, 1.0, 2))
-        dropdown_layout.addWidget(self.tdr_velocity_input)
+        dropdown_layout.addWidget(self.tdr_velocity_input, 0)
+        dropdown_layout.addWidget(QtWidgets.QLabel(), 1)
 
         layout.addRow(dropdown_layout)
 
+        format_window_layout = QtWidgets.QHBoxLayout()
         self.format_dropdown = QtWidgets.QComboBox()
         self.format_dropdown.addItem("|Z| (lowpass)")
         self.format_dropdown.addItem("S11 (lowpass)")
@@ -155,14 +157,21 @@ class TDRWindow(QtWidgets.QWidget):
         self.format_dropdown.addItem("Refl (bandpass)")
 
         self.format_dropdown.currentIndexChanged.connect(self.updateFormat)
-        layout.addRow("Format", self.format_dropdown)
+        format_window_layout.addWidget(QtWidgets.QLabel("Format"), 0)
+        format_window_layout.addWidget(self.format_dropdown, 1)
 
         self.window_dropdown = QtWidgets.QComboBox()
         for method_name, method_call, method_correction, method_arg in WINDOWING_FUNCTION:
-            self.window_dropdown.addItem(method_name, {'function': method_call, 'arg': method_arg, 'corr': method_correction})
+            self.window_dropdown.addItem(
+                method_name,
+                {'function': method_call, 'arg': method_arg, 'corr': method_correction})
         self.window_dropdown.currentIndexChanged.connect(self.updateTDR)
         self.window_dropdown.setCurrentIndex(0)
-        layout.addRow("Window", self.window_dropdown)
+
+        format_window_layout.addWidget(QtWidgets.QLabel("Window"), 0)
+        format_window_layout.addWidget(self.window_dropdown, 1)
+        format_window_layout.addWidget(QtWidgets.QLabel(" "), 1)
+        layout.addRow(format_window_layout)
 
         self.tdr_result_label = QtWidgets.QLabel()
         layout.addRow("Estimated cable length:", self.tdr_result_label)


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- Application crashed, when trying to draw zoom rectangle (ctrl-modifiers) in TDR window
- Panning with keys was not possible
- No choice of window function for fft
- Zooming by scrolling the mouse wheel was not working

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Fixed crash, ctrl-zooming now possible.
- One can pan the graph using arrow keys
- One can zoom using the mouse wheel
- Drop down with different window functions (kaiser with different betas to mimic nanovna, hanning, blackman)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
