### PR TITLE
Add missing return in hardware/NanoVNA_F_V2.py function get_features

### DIFF
--- a/src/NanoVNASaver/Hardware/NanoVNA_F_V2.py
+++ b/src/NanoVNASaver/Hardware/NanoVNA_F_V2.py
@@ -65,6 +65,18 @@ class NanoVNA_F_V2(NanoVNA):
         except serial.SerialException as exc:
             logger.exception("Exception while capturing screenshot: %s", exc)
         return QPixmap()
+    """
+    Add missing function to fix SN display in device setting window
+    Copied from _F_V3
+    """
+
+    def init_features(self) -> None:
+        super().init_features()
+        result = " ".join(self.exec_command("help")).lower().split()
+        if "sn:" in result:
+            self.features.add("SN")
+            self.SN = self.getSerialNumber()
+
 
     def read_firmware_version(self) -> "Version":
         """For example, command version in NanoVNA_F_V2 and NanoVNA_F_V3
@@ -80,6 +92,7 @@ class NanoVNA_F_V2(NanoVNA):
         if "sn:" or "SN:" in result:
             self.features.add("SN")
             self.SN = self.getSerialNumber()
+        return self.features    # add missing return fixes combobox not getting initialized with proper values for valid sweep points
 
     def getSerialNumber(self) -> str:
         return (


### PR DESCRIPTION
Add init_features to fix SN not showing in device setting window
Add return statement at end of get_features function.  Both changes in hardware/NanoVNA_F_V2

<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 38
## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
After connecting device to usb and selecting "manage" button, info box now has SN info.
Selecting ComboBox for valid sweep points show all options, not just 101.
<img width="491" alt="2025-03-27_11-56-18" src="https://github.com/user-attachments/assets/a9b30d16-fefb-44fd-9e34-8d83cf3dd004" />

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [X ] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
I've only tested in Windows 10.  This is my first PULL request so I apologize in advance for any improper actions! 
