### PR TITLE
TDR: prevent zooming if no data

### DIFF
--- a/src/NanoVNASaver/Charts/TDR.py
+++ b/src/NanoVNASaver/Charts/TDR.py
@@ -37,7 +37,6 @@ from PySide6.QtGui import (
 )
 from PySide6.QtWidgets import QDialog, QInputDialog, QMenu, QSizePolicy
 
-from ..RFTools import Datapoint
 from .Chart import Chart, ChartPosition
 
 logger = logging.getLogger(__name__)
@@ -343,10 +342,6 @@ class TDRChart(Chart):
 
     def wheelEvent(self, a0: QWheelEvent) -> None:
         a0.accept()
-        self.data = [
-            Datapoint(0, 0.0, 0.0)
-        ]  # A bit of cheating otherwise the super().wheelEvent() exits
-        # without doing anything.
         super().wheelEvent(a0)
 
     def mouseMoveEvent(self, a0: QMouseEvent) -> None:

--- a/src/NanoVNASaver/Windows/TDR.py
+++ b/src/NanoVNASaver/Windows/TDR.py
@@ -28,6 +28,7 @@ from PySide6.QtGui import QShortcut
 from scipy.constants import speed_of_light  # type: ignore
 from scipy.signal import convolve  # type: ignore
 
+from ..RFTools import Datapoint
 from .Defaults import make_scrollable
 from .ui import get_window_icon
 
@@ -292,6 +293,10 @@ class TDRWindow(QtWidgets.QWidget):
         self.tdr_result_label.setText(f"{cable_len}m ({feet}ft {inches}in)")
         self.app.tdr_result_label.setText(f"{cable_len}m")
         self.td = list(td)
+        self.app.tdr_chart.data = [
+            Datapoint(0, 0.0, 0.0)
+        ]  # A bit of cheating otherwise the super().wheelEvent() exits
+        # without doing anything.
         self.updated.emit()
 
     def _tdr_lowpass(self, tdr_format, s11, tdr_window) -> np.ndarray:


### PR DESCRIPTION
Before connecting to the device, trying to zoom (mouse wheel event) on empty TDR chart was causing error

!!IMPORTANT!!
tox failed with coverage with following error:
coverage: exit 1 (4.35 seconds) /home/mi/docs/prog/python/nanovna-saver> pytest --cov=src tests/ pid=364
  py310: OK (1.76=setup[0.01]+cmd[1.75] seconds)
  py311: OK (1.82=setup[0.00]+cmd[1.82] seconds)
  py312: OK (1.74=setup[0.00]+cmd[1.74] seconds)
  coverage: FAIL code 1 (4.35=setup[0.00]+cmd[4.35] seconds)
  evaluation failed :( (9.75 seconds)



## Pull Request type

small bug correcting

Please check the type of change your PR introduces:

- [ x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

now the mouse wheel event is ignored if no data is present

Issue Number: N/A

## What is the new behavior?

N/A

## Does this introduce a breaking change?

- [ ] Yes
- [ x] No


## Other information

Simply moved fake data to cheat chart.py from chart/TDR.py:wheelEvent() to windows/TDR.py:updateTDR()