### PR TITLE
Relaxing python version requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 maintainers = [
     { name = "Holger Mueller", email = "zarath@gmx.de" }
 ]
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10"
 license = {text = "GPL-3.0-or-later"}
 readme = "README.rst"
 


### PR DESCRIPTION
This allows to build on e.g. Fedora 42 where we have Python 3.13.5. Fixes #813 by modifying the `requires-python` line in `pyproject.toml`. Basically I just applied the patch from the ticket.

## Pull Request type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Build fails with error:
```
ERROR: Package 'nanovnasaver' requires a different Python: 3.13.5 not in '<3.13,>=3.10'
```
Issue Number: 813

## What is the new behavior?
Build completes successfully.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No