### PR TITLE
Fixing build with pip install and update documentation

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,37 +1,20 @@
 # Installation Instructions
 
-## Installation and Use with pip
+## Installation and Use with pipx
+For installation it is recommended to use pipx instead of pip.  Most installations nowadays require the usage of a virtual environment when using pip, pipx automatically arranges this for you.
 
-Copy the link of the tgz from latest relaese and install it with pip install. e.g.:
+Installing the latest release with pipx install. e.g.:
 
-    pip3 install https://github.com/NanoVNA-Saver/nanovna-saver/archive/refs/tags/v0.5.5.tar.gz
+    pipx install git+https://github.com/NanoVNA-Saver/nanovna-saver
+
+Or if you want to install a specific version use:
+
+    pipx install git+https://github.com/NanoVNA-Saver/nanovna-saver@v0.7.3
 
 Once completed run with the following command: `NanoVNASaver`
 
-The instructions omit the easiest way to get the program running under Linux - no installation - just start it in the git directory. This makes it difficult for pure users, e.g. hams, who therefore even try to run the Windows exe version under Wine.
-
-Proposal - Add these sections below to the top README.md, e.g. between "Detailed installation instructions" and "Using the software" (Please review and add e.g. more necessary debian packages):
-
-## Running on Linux without installation
-
-The program simply works from the source directory without having to install it.
-
-Simple step-by-step instruction, open a terminal window and type:
-
-    sudo apt install git python3-pyqt5 python3-numpy python3-scipy
-    git clone https://github.com/NanoVNA-Saver/nanovna-saver
-    cd nanovna-saver
-
-Perhaps your system needs a few additional python modules:
-
-- Run with `python nanovna-saver.py` and look at the response of (e.g. missing modules).
-- Install the missing modules, preferably via `sudo apt install ...`
-
-until `nanovna-saver.py` starts up.
-
-Now the program can be used from the `nanovna-saver` directory.
-
 ## Installing via DEB for Debian (and Ubuntu)
+🚧 TODO: this is currently broken
 
 The installation has the benefit that it allows you to run the program from anywhere, because the
 main program is found via the regular `$PATH` and the modules are located in the Python module path.
@@ -55,35 +38,9 @@ or
    sudo apt install ./nanovnasaver....deb
 
 ### Installing via RPM (experimental)
+🚧 TODO: this is currently broken
 
 `make rpm` builds an (untested) rpm package that can be installed on your system the usual way.
-
-## Ubuntu 20.04 / 22.04 / 24.04
-
-1. Install python3 and pip
-
-        sudo apt install python3 python3-pip libxcb-cursor-dev
-        python3 -m venv ~/.venv_nano
-        . ~/.venv_nano/bin/activate
-        pip install -U pip
-
-2. Clone repo and cd into the directory
-
-        git clone https://github.com/NanoVNA-Saver/nanovna-saver
-        cd nanovna-saver
-
-3. Update pip and run the pip installation
-
-        python3 -m pip install .
-
-   (You may need to install the additional packages python3-distutils,
-   python3-setuptools and python3-wheel for this command to work on some
-   distributions.)
-
-4. Once completed run with the following command
-
-        . ~/.venv_nano/bin/activate
-        python3 nanovna-saver.py
 
 ## Automated MacOS Build Script
 
@@ -137,6 +94,6 @@ Via a MacPorts distribution maintained by @ra1nb0w.
 
         python3 -m pip install .
 
-6. Run nanovna-saver in the nanovna-saver folder by:
+6. Run nanovna-saver folder by:
 
-        python3 nanovna-saver.py
+        NanoVNASaver

--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -1,2 +1,2 @@
 .. _authors:
-.. include:: ../AUTHORS.rst
+.. include:: ../licenses/AUTHORS.rst

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -4,4 +4,4 @@
 License
 =======
 
-.. include:: ../LICENSE.txt
+.. include:: ../licenses/LICENSE.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,8 +72,8 @@ requires = [
 # build-backend = 'setuptools.build_meta'
 # in-tree build backend, wrapper around setuptools, just to run ui-compile task
 # See also https://setuptools.pypa.io/en/latest/build_meta.html#dynamic-build-dependencies-and-other-build-meta-tweaks
-build-backend = "setuptools_wrapper"
-backend-path = ["src/tools"]
+build-backend = "src.tools.setuptools_wrapper"
+backend-path = ["."]
 
 [tool.setuptools.exclude-package-data]
 "*" = ['*.png', '*.ui', '*.qrc' ]

--- a/src/tools/setuptools_wrapper.py
+++ b/src/tools/setuptools_wrapper.py
@@ -5,7 +5,7 @@ from setuptools.build_meta import *  # Do not remove this line, it's nedded!  # 
 
 
 def compile_ui() -> None:
-    protoc_call = ["python", "-m", "src.tools.ui_compile"]
+    protoc_call = ["python3", "-m", "src.tools.ui_compile"]
     subprocess.call(protoc_call)
 
 


### PR DESCRIPTION
The current installation instructions for Linux are not working anymore.

This pull request updates the build script so that setuptools properly runs the ui compilation, which should allow installing using just pip again.

It also updates the documentation to provide correct instructions for the installation and to mark the creation of .deb and .rpm packages as a known issue.

This should fix the underlying complaints of #828 #831 #815 #808 #788

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Current installation instructions don't work on Linux

Issue Number: #828 #831 #815 #808 #788

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- A small bugfix to the build scripts (setuptools assumed a different working directory than the ui_compile script)
- New instructions
- Marked .deb and .rpm instructions as known broken in the documentation

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
