### PR TITLE
Fixed the issue in SV4401A/SV6301A v0.7.1 firmware caused 

### DIFF
--- a/src/NanoVNASaver/Hardware/SV4401A.py
+++ b/src/NanoVNASaver/Hardware/SV4401A.py
@@ -44,6 +44,12 @@ class SV4401A(NanoVNA):
         super().__init__(iface)
         self.sweep_max_freq_hz = 4.4e9
 
+    def init_features(self) -> None:
+        super().init_features()
+        self.features.remove("Scan mask command")
+        self.features.add("Scan command")
+        self.sweep_method = "scan"
+
     def getScreenshot(self) -> QPixmap:
         logger.debug("Capturing screenshot...")
         self.serial.timeout = 8

--- a/src/NanoVNASaver/Hardware/SV6301A.py
+++ b/src/NanoVNASaver/Hardware/SV6301A.py
@@ -43,6 +43,12 @@ class SV6301A(NanoVNA):
     def __init__(self, iface: Interface):
         super().__init__(iface)
         self.sweep_max_freq_hz = 6.3e9
+        
+    def init_features(self) -> None:
+        super().init_features()
+        self.features.remove("Scan mask command")
+        self.features.add("Scan command")
+        self.sweep_method = "scan"
 
     def getScreenshot(self) -> QPixmap:
         logger.debug("Capturing screenshot...")


### PR DESCRIPTION
# Fixed the issue in SV4401A/SV6301A v0.7.1 firmware caused by missing scan_mask command.

<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The code in NanoVNA.py in the main code causes the program to not work as expected when using firmware version 0.7.1 on SV4401A/SV6301A, due to the use of the undefined command 'scan_mask'：

```
def init_features(self) -> None:
        super().init_features()
        if self.version >= Version.parse("0.7.1"):
            logger.debug("Using scan mask command.")
            self.features.add("Scan mask command")
            self.sweep_method = "scan_mask"
        elif self.version >= Version.parse("0.2.0"):
            logger.debug("Using new scan command.")
            self.features.add("Scan command")
            self.sweep_method = "scan"
```


## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Override this method in the SV4401A/SV6301A classes to always use the "scan" command.

```
def init_features(self) -> None:
        super().init_features()
        self.features.remove("Scan mask command")
        self.features.add("Scan command")
        self.sweep_method = "scan"
```


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
After applying this change, the SV4401A/SV6301A can operate as expected, but after enabling Continuous Sweep, it occasionally malfunctions and displays warning pop-up messages(on Windows 10).
This is an error log:

```
2025-10-22 10:38:07,677 - NanoVNASaver.Hardware.VNA - DEBUG - exec_command(scan 1000000 6300000000 501)
2025-10-22 10:38:07,730 - NanoVNASaver.SweepWorker - ERROR - Cannot configure port, something went wrong. Original message: PermissionError(13, '连到系统上的设备没有发挥作用。', None, 31)
Traceback (most recent call last):
  File "E:\nanovna\nanovna-saver\src\NanoVNASaver\Hardware\SV6301A.py", line 67, in setSweep
    list(self.exec_command(f"scan {start} {stop} {self.datapoints}"))
    ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\nanovna\nanovna-saver\src\NanoVNASaver\Hardware\VNA.py", line 105, in exec_command
    drain_serial(self.serial)
    ~~~~~~~~~~~~^^^^^^^^^^^^^
  File "E:\nanovna\nanovna-saver\src\NanoVNASaver\Hardware\Serial.py", line 35, in drain_serial
    serial_port.timeout = timeout
    ^^^^^^^^^^^^^^^^^^^
  File "E:\Python313\Lib\site-packages\serial\serialutil.py", line 372, in timeout
    self._reconfigure_port()
    ~~~~~~~~~~~~~~~~~~~~~~^^
  File "E:\Python313\Lib\site-packages\serial\serialwin32.py", line 222, in _reconfigure_port
    raise SerialException(
        'Cannot configure port, something went wrong. '
        'Original message: {!r}'.format(ctypes.WinError()))
serial.serialutil.SerialException: Cannot configure port, something went wrong. Original message: PermissionError(13, '连到系统上的设备没有发挥作用。', None, 31)
2025-10-22 10:38:11,951 - NanoVNASaver.Hardware.VNA - INFO - disconnect COM4 (SV6301A)
2025-10-22 10:38:12,002 - NanoVNASaver.Hardware.VNA - INFO - connect COM4 (SV6301A)
2025-10-22 10:42:54,031 - NanoVNASaver.Controls.SerialControl - INFO - Closing connection to COM4 (SV6301A)
2025-10-22 10:42:54,031 - NanoVNASaver.Hardware.VNA - INFO - disconnect COM4 (SV6301A)
```
According to the log, the crash was likely caused by a serial data reception timeout, which triggered the software to automatically reset the device, and an exception occurred during the reset process.

In the serialwin32.py file, locate the following code:

```
    def _reconfigure_port(self):
    
        ...
        
        if not win32.SetCommState(self._port_handle, ctypes.byref(comDCB)):
            raise SerialException(
                'Cannot configure port, something went wrong. '
               'Original message: {!r}'.format(ctypes.WinError()))
```
Change it to the following code:

```
    def _reconfigure_port(self):
    
        ...
        
        if not win32.SetCommState(self._port_handle, ctypes.byref(comDCB)):
            pass
            #raise SerialException(
            #    'Cannot configure port, something went wrong. '
            #   'Original message: {!r}'.format(ctypes.WinError()))
```
After restarting, the problem was resolved.

As for why this happens, it may be related to the fact that the SV4401A/SV6301A use USB HS 2.0, which behaves differently under the Windows mechanism.
