### PR TITLE
ci: add macOS release workflow

### DIFF
--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -1,0 +1,49 @@
+name: macOS Release
+
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: macos-14
+    strategy:
+      matrix:
+        arch: [arm64]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.13
+        architecture: ${{ matrix.arch }}
+
+    - name: Install dependencies and pyinstall
+      run: |
+        python -m pip install uv
+        uv sync
+
+    - name: Build app
+      run: |
+        uv run task ui-compile
+        uv run task build-pkg-macos
+
+    - name: Verify artifact
+      run: |
+        set -eux
+        test -f "dist/NanoVNASaver.app-$(uname -m).tar.gz"
+        ls -lh dist/NanoVNASaver.app-*.tar.gz
+
+    - name: Archive production artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: NanoVNASaver.macos.${{ matrix.arch }}
+        path: dist/NanoVNASaver.app-*.tar.gz
+        if-no-files-found: error


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

There is currently no GitHub Actions release workflow for building and uploading a macOS NanoVNASaver `.app` artifact.

Issue Number: N/A

## What is the new behavior?

- Adds a macOS release workflow that runs on `macos-14`.
- Builds an arm64 macOS application artifact using Python 3.13 and `uv`.
- Reuses the existing project tasks: `ui-compile` and `build-pkg-macos`.
- Uploads the generated `NanoVNASaver.app-*.tar.gz` artifact as `NanoVNASaver.macos.arm64`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The workflow was tested successfully with `workflow_dispatch` on `macos-14-arm64`.

The generated artifact was downloaded, extracted, and launched locally on macOS using Gatekeeper's “Open Anyway” flow.